### PR TITLE
Confidence calibration: irrigation recency, DVR vacancy scaling, clam…

### DIFF
--- a/classifications/nzlum/classes/class_117.sql
+++ b/classifications/nzlum/classes/class_117.sql
@@ -7,7 +7,7 @@ CREATE TEMPORARY VIEW class_117 AS (
         WHEN pan_nz_not_iucn.h3_index IS NOT NULL
         THEN ROW(
             ARRAY[]::TEXT[], -- lu_code_ancillary
-            LEAST(GREATEST(
+            clamp_confidence_or_null(
                 CASE
                     WHEN (
                         legislation_act IN (
@@ -74,7 +74,7 @@ CREATE TEMPORARY VIEW class_117 AS (
                 + CASE WHEN rural.h3_index IS NULL THEN 1 ELSE 0 END
                 -- Penalise built land-cover including urban parks
                 + CASE WHEN lcdb_unbuilt.h3_index IS NULL THEN 1 ELSE 0 END
-            END, 1), 12),
+            END),
             ARRAY[]::TEXT[], -- commod
             ARRAY[]::TEXT[], -- manage
             ARRAY[pan_nz_not_iucn.source_data],

--- a/classifications/nzlum/classes/class_220.sql
+++ b/classifications/nzlum/classes/class_220.sql
@@ -86,6 +86,14 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                     '76 - Grassland - Low producing'
                 )
                 THEN 14 -- >12 to account for modifier
+
+                -- Gap-fill: LCDB High Producing Exotic Grassland with no DVR data
+                WHEN (
+                    lcdb_.Class_2018 IN (40, 41)
+                    AND linz_dvr_.h3_index IS NULL
+                )
+                THEN 4
+
                 ELSE NULL -- No other possibilities permitted
             END
             + -- Add modifier for landcover
@@ -121,7 +129,7 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
             +
             CASE -- Lower confidence for land in hydro parcel
                 WHEN hydro_parcels_h3.h3_index IS NOT NULL
-                THEN 2
+                THEN 1
                 ELSE 0
             END
             +
@@ -224,9 +232,10 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                 h3_index,
                 source_data,
                 source_date,
-                source_scale
+                source_scale,
+                Class_2018
             FROM lcdb_
-            WHERE Class_2018 IN (10, 12, 15, 16, 20, 21, 30, 41, 44, 51, 52, 55, 56, 58, 80, 81, 64)
+            WHERE Class_2018 IN (10, 12, 15, 16, 20, 21, 30, 40, 41, 44, 51, 52, 55, 56, 58, 80, 81, 64)
         ) AS lcdb_ ON roi.h3_index && lcdb_.h3_index
         LEFT JOIN (
             SELECT

--- a/classifications/nzlum/classes/class_230.sql
+++ b/classifications/nzlum/classes/class_230.sql
@@ -10,7 +10,7 @@ CREATE TEMPORARY VIEW class_230 AS (
     0 AS lu_code_tertiary,
     ROW(
         ARRAY[]::TEXT[], -- lu_code_ancillary
-        LEAST(GREATEST(CASE
+        clamp_confidence_or_null(CASE
             WHEN (
                 lcdb_.h3_index IS NOT NULL
                 OR lum_.h3_index IS NOT NULL
@@ -107,7 +107,15 @@ CREATE TEMPORARY VIEW class_230 AS (
             THEN -1
             ELSE 0
         END
-        , 1), 12), -- confidence
+        +
+        CASE -- Penalise confidence by irrigation age (older mapping = less certain)
+            WHEN irrigation_.irrigation_age IS NULL THEN 0
+            WHEN irrigation_.irrigation_age <= 5    THEN 0
+            WHEN irrigation_.irrigation_age <= 10   THEN 1
+            WHEN irrigation_.irrigation_age <= 20   THEN 2
+            ELSE 3
+        END
+        ), -- confidence
         (
             CASE
                 WHEN linz_dvr_.actual_property_use = '11'
@@ -196,10 +204,11 @@ CREATE TEMPORARY VIEW class_230 AS (
         OR category ~ '^H(B|F|M|X)(A|B|C|D|E|F)?' -- Berry fruits, flowers, market gardens, other hort/mixed
     ) linz_dvr_ ON roi.h3_index && linz_dvr_.h3_index
     LEFT JOIN (
-        SELECT h3_index, source_data, source_scale, source_date, manage
+        SELECT h3_index, source_data, source_scale, source_date, manage, irrigation_age
         FROM irrigation_
-        WHERE ts_notes IS NULL -- Very important
-        OR NOT (ts_notes @@ to_tsquery('english', 'sports & field | golf & course'))
+        WHERE (ts_notes IS NULL -- Very important
+            OR NOT (ts_notes @@ to_tsquery('english', 'sports & field | golf & course')))
+        AND irrigation_type !~ '^Drip' -- Drip is characteristic of perennial/intensive horticulture (class 240/250), not short-rotation cropping
     ) irrigation_ ON roi.h3_index && irrigation_.h3_index
     LEFT JOIN (
         SELECT h3_index, source_data, source_scale, source_date, manage, commod

--- a/classifications/nzlum/classes/class_240.sql
+++ b/classifications/nzlum/classes/class_240.sql
@@ -352,6 +352,13 @@ CREATE TEMPORARY VIEW class_240 AS ( -- Perennial horticulture
                         WHEN crop_perennial.h3_index IS NOT NULL
                         THEN -6
                         ELSE 0
+                    END
+                    + CASE -- Penalise confidence by irrigation age (older mapping = less certain)
+                        WHEN irrigation_.irrigation_age IS NULL THEN 0
+                        WHEN irrigation_.irrigation_age <= 5    THEN 0
+                        WHEN irrigation_.irrigation_age <= 10   THEN 1
+                        WHEN irrigation_.irrigation_age <= 20   THEN 2
+                        ELSE 3
                     END, 1), 12) -- confidence
             END,
             COALESCE((nzlum_type).commod, ARRAY[]::TEXT[]) || COALESCE(crop_perennial.commod, ARRAY[]::TEXT[]),
@@ -381,13 +388,10 @@ CREATE TEMPORARY VIEW class_240 AS ( -- Perennial horticulture
             source_data,
             source_date,
             source_scale,
-            manage
+            manage,
+            irrigation_age
         FROM irrigation_
-        WHERE irrigation_type IN (
-            'Drip/micro',
-            'Drip/Micro',
-            'Drip/ Micro'
-        )
+        WHERE irrigation_type ~ '^Drip'
     ) irrigation_ ON base_classification.h3_index && irrigation_.h3_index
 );
 

--- a/classifications/nzlum/classes/class_250.sql
+++ b/classifications/nzlum/classes/class_250.sql
@@ -91,26 +91,37 @@ CREATE TEMPORARY VIEW class_250 AS ( -- Intensive horticulture
             WHEN irrigation_.h3_index IS NOT NULL
             THEN -1
             ELSE 0
+        END
+        +
+        CASE -- Penalise confidence by irrigation age (older mapping = less certain)
+            WHEN irrigation_.irrigation_age IS NULL THEN 0
+            WHEN irrigation_.irrigation_age <= 5    THEN 0
+            WHEN irrigation_.irrigation_age <= 10   THEN 1
+            WHEN irrigation_.irrigation_age <= 20   THEN 2
+            ELSE 3
         END), -- Confidence - exclude values over 12 rather than clamping down to 12
         ARRAY[]::TEXT[], -- commod
         ARRAY[irrigation_.manage]::TEXT[] || COALESCE(crop_nurseries.manage, ARRAY[]::TEXT[]), -- manage
         ARRAY[
             linz_dvr_.source_data,
             irrigation_.source_data,
-            crop_nurseries.source_data
+            crop_nurseries.source_data,
+            lcdb_.source_data
         ]::TEXT[], -- source_data
         range_merge(datemultirange(
             VARIADIC ARRAY_REMOVE(ARRAY[
                 irrigation_.source_date,
                 linz_dvr_.source_date,
-                crop_nurseries.source_date
+                crop_nurseries.source_date,
+                lcdb_.source_date
             ], NULL)
         ))::daterange, -- source_date
         range_merge(int4multirange(
             VARIADIC ARRAY_REMOVE(ARRAY[
                 irrigation_.source_scale,
                 linz_dvr_.source_scale,
-                crop_nurseries.source_scale
+                crop_nurseries.source_scale,
+                lcdb_.source_scale
             ], NULL)
         ))::int4range, -- source_scale
         NULL
@@ -154,7 +165,8 @@ CREATE TEMPORARY VIEW class_250 AS ( -- Intensive horticulture
             source_data,
             source_date,
             source_scale,
-            manage
+            manage,
+            irrigation_age
         FROM irrigation_
         WHERE :parent::h3index = h3_partition
         AND irrigation_type ~ '^Drip'

--- a/classifications/nzlum/classes/class_270.sql
+++ b/classifications/nzlum/classes/class_270.sql
@@ -31,16 +31,19 @@ CREATE TEMPORARY VIEW class_270 AS ( -- Water and wastewater
             ARRAY[]::TEXT[], -- manage
             ARRAY[
                 unspecified_waterbodies.source_data,
-                linz_dvr_rural.source_data
-            ]::TEXT,
-            range_merge(
+                linz_dvr_rural.source_data,
+                lcdb_.source_data
+            ]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
                 unspecified_waterbodies.source_date,
-                linz_dvr_rural.source_date
-            ),
-            range_merge(
+                linz_dvr_rural.source_date,
+                lcdb_.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
                 unspecified_waterbodies.source_scale,
-                linz_dvr_rural.source_scale
-            ),
+                linz_dvr_rural.source_scale,
+                lcdb_.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type
         WHEN lakes.h3_index IS NOT NULL
@@ -113,7 +116,7 @@ CREATE TEMPORARY VIEW class_270 AS ( -- Water and wastewater
         AND actual_property_use != '18' -- Mineral extraction
     ) linz_dvr_rural ON roi.h3_index && linz_dvr_rural.h3_index
     LEFT JOIN (
-        SELECT h3_index
+        SELECT h3_index, source_data, source_date, source_scale
         FROM lcdb_
         WHERE class_2018 IN (
             20, -- Lake or pond

--- a/classifications/nzlum/classes/class_280_v2.sql
+++ b/classifications/nzlum/classes/class_280_v2.sql
@@ -10,22 +10,28 @@ filtered_linz AS (
         source_data,
         source_date,
         source_scale,
+        current_effective_valuation_date,
         actual_property_use,
         category,
         "zone",
         improvements_value,
-        improvements_description
+        improvements_description,
+        sized_for_lifestyle
     FROM linz_dvr_
     WHERE
         :parent::h3index = h3_partition
-        AND actual_property_use IN ('00', '19', '29')
+        AND actual_property_use IN (
+            '00', -- 0.0 Multi-use at primary level (primary: 0=vacant/intermediate, secondary: 0=multi-use)
+            '19', -- 1.9 Rural industry, vacant (primary: 1=rural industry, secondary: 9=vacant)
+            '29'  -- 2.9 Lifestyle, vacant (primary: 2=lifestyle, secondary: 9=vacant)
+        )
         AND (
             "zone" ~ '^(0X|[1245][A-Z])'
             OR category ~ '^[ADFHLOPS]'
         )
 ),
 filtered_lcdb AS (
-    SELECT h3_index, Class_2018
+    SELECT h3_index, Class_2018, source_data, source_date, source_scale
     FROM lcdb_
     WHERE
         :parent::h3index = h3_partition
@@ -93,29 +99,56 @@ unioned_matches AS (
 
     UNION ALL
 
-    -- Match 2: LINZ vacant rural
+    -- Match 2: LINZ vacant rural (1.9 Rural industry, vacant)
     SELECT
         roi.h3_index,
         2, 8, 0,
         ROW(
             ARRAY[]::TEXT[],
-            CASE
-                WHEN l.zone !~ '^[01]' -- Not zoned for rural (or not mixed zone)
-                    THEN 8
-                WHEN filtered_lcdb.Class_2018 = 71 -- Exotic Forest
-                    THEN 9
-                WHEN (
-                    l.category LIKE '_V%' -- Vacant
-                    OR l.improvements_value < 100000 -- No considerable improvements built
-                )
+            LEAST(GREATEST(
+                CASE
+                    WHEN l.zone !~ '^[01]' -- Not zoned for rural (or not mixed zone)
+                        THEN 8
+                    WHEN filtered_lcdb.Class_2018 = 71 -- Exotic Forest
+                        THEN 9
+                    WHEN (
+                        l.category LIKE '_V%' -- Vacant
+                        OR l.improvements_value < 100000 -- No considerable improvements built
+                    )
+                        THEN 1
+                    ELSE 2
+                END
+                + CASE
+                    WHEN filtered_lcdb.Class_2018 IN (30, 33) THEN 2 -- LCDB suggests active cropland/orchard; penalise vacant classification
+                    ELSE 0
+                END
+                + CASE -- Penalise by valuation recency: older vacancy records are less reliable
+                    WHEN l.current_effective_valuation_date IS NULL
+                    THEN 2
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '1 year'
+                    THEN 0
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '3 years'
                     THEN 1
-                ELSE 2
-            END,
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '6 years'
+                    THEN 2
+                    ELSE 3
+                END
+                + CASE -- Residential-sized properties (0.4–2ha) are unlikely vacant agricultural land; likely rural-residential (→ 3.9.0)
+                    WHEN l.sized_for_lifestyle THEN 4
+                    ELSE 0
+                END
+            , 1), 12),
             ARRAY[]::TEXT[],
             ARRAY[]::TEXT[],
-            ARRAY[l.source_data]::TEXT[],
-            l.source_date,
-            l.source_scale,
+            ARRAY[l.source_data, filtered_lcdb.source_data]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                l.source_date,
+                filtered_lcdb.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                l.source_scale,
+                filtered_lcdb.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type,
         2
@@ -123,12 +156,12 @@ unioned_matches AS (
     JOIN filtered_linz l ON roi.h3_index && l.h3_index
     JOIN filtered_lcdb ON roi.h3_index && filtered_lcdb.h3_index
     WHERE
-        l.actual_property_use = '19'
+        l.actual_property_use = '19' -- 1.9 Rural industry, vacant
         AND l.category ~ '^[ADFHOPS]'
 
     UNION ALL
 
-    -- Match 3: Lifestyle vacant with orchard hint
+    -- Match 3: Lifestyle vacant with orchard hint (2.9 Lifestyle, vacant)
     -- Orchard improvements on a vacant property suggest past agricultural use,
     -- not necessarily active production. Active orchards → class 2.3.x.
     SELECT
@@ -136,22 +169,48 @@ unioned_matches AS (
         2, 8, 0,
         ROW(
             ARRAY[]::TEXT[],
-            CASE
-                WHEN l.improvements_description ~ '\mORCHARDS?\M'
-                    THEN CASE
-                        WHEN l.zone ~ '^1' THEN 1 -- Orchard improvements in rural zone
-                        WHEN l.zone ~ '^0' THEN 3 -- Orchard improvements, multiple zones
-                        ELSE 4                    -- Orchard improvements, other zone
-                    END
-                WHEN l.zone ~ '^1' THEN 3         -- Rural zone, no orchard hint
-                WHEN l.zone ~ '^0' THEN 5         -- Multiple zones, no orchard hint
-                ELSE 7
-            END,
+            LEAST(GREATEST(
+                CASE
+                    WHEN l.improvements_description ~ '\mORCHARDS?\M'
+                        THEN CASE
+                            WHEN l.zone ~ '^1' THEN 3 -- Orchard improvements in rural zone
+                            WHEN l.zone ~ '^0' THEN 3 -- Orchard improvements, multiple zones
+                            ELSE 3                    -- Orchard improvements, other zone
+                        END
+                    WHEN l.zone ~ '^1' THEN 3         -- Rural zone, no orchard hint
+                    WHEN l.zone ~ '^0' THEN 5         -- Multiple zones, no orchard hint
+                    ELSE 7
+                END + CASE
+                    WHEN filtered_lcdb.Class_2018 IN (30, 33) THEN 2 -- Be wary of apparently "vacant" orchards; penalise vacant classification if there is an orchard signal in LCDB
+                    ELSE 0
+                END
+                + CASE -- Penalise by valuation recency: older vacancy records are less reliable
+                    WHEN l.current_effective_valuation_date IS NULL
+                    THEN 2
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '1 year'
+                    THEN 0
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '3 years'
+                    THEN 1
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '6 years'
+                    THEN 2
+                    ELSE 3
+                END
+                + CASE -- Residential-sized properties (0.4–2ha) are unlikely vacant agricultural land; likely rural-residential (→ 3.9.0)
+                    WHEN l.sized_for_lifestyle THEN 4
+                    ELSE 0
+                END
+            , 1), 12),
             ARRAY[]::TEXT[],
             ARRAY[]::TEXT[],
-            ARRAY[l.source_data]::TEXT[],
-            l.source_date,
-            l.source_scale,
+            ARRAY[l.source_data, filtered_lcdb.source_data]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                l.source_date,
+                filtered_lcdb.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                l.source_scale,
+                filtered_lcdb.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type,
         3
@@ -160,29 +219,52 @@ unioned_matches AS (
     JOIN filtered_lcdb ON roi.h3_index && filtered_lcdb.h3_index
     JOIN filtered_rural_other ON roi.h3_index && filtered_rural_other.h3_index
     WHERE
-        l.actual_property_use = '29'
+        l.actual_property_use = '29' -- 2.9 Lifestyle, vacant
         AND l.category LIKE 'LV%'
 
     UNION ALL
 
-    -- Match 4: LINZ '00' multi-use
+    -- Match 4: LINZ '00' multi-use (0.0 Multi-use at primary level / vacant intermediate)
     SELECT
         roi.h3_index,
         2, 8, 0,
         ROW(
             ARRAY[]::TEXT[],
-            CASE
-                WHEN l.category LIKE '_V%'
-                    THEN 3
-                WHEN filtered_lcdb.Class_2018 = 71 -- Exotic Forest
-                    THEN 9
-                ELSE 4
-            END,
+            LEAST(GREATEST(
+                CASE
+                    WHEN l.category LIKE '_V%'
+                        THEN 3
+                    WHEN filtered_lcdb.Class_2018 = 71 -- Exotic Forest
+                        THEN 9
+                    ELSE 4
+                END
+                + CASE -- Penalise by valuation recency: older vacancy records are less reliable
+                    WHEN l.current_effective_valuation_date IS NULL
+                    THEN 2
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '1 year'
+                    THEN 0
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '3 years'
+                    THEN 1
+                    WHEN l.current_effective_valuation_date > CURRENT_DATE - INTERVAL '6 years'
+                    THEN 2
+                    ELSE 3
+                END
+                + CASE -- Residential-sized properties (0.4–2ha) are unlikely vacant agricultural land; likely rural-residential (→ 3.9.0)
+                    WHEN l.sized_for_lifestyle THEN 4
+                    ELSE 0
+                END
+            , 1), 12),
             ARRAY[]::TEXT[],
             ARRAY[]::TEXT[],
-            ARRAY[l.source_data]::TEXT[],
-            l.source_date,
-            l.source_scale,
+            ARRAY[l.source_data, filtered_lcdb.source_data]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                l.source_date,
+                filtered_lcdb.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                l.source_scale,
+                filtered_lcdb.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type,
         4
@@ -190,7 +272,7 @@ unioned_matches AS (
     JOIN filtered_linz l ON roi.h3_index && l.h3_index
     JOIN filtered_lcdb ON roi.h3_index && filtered_lcdb.h3_index
     JOIN filtered_rural_other ON roi.h3_index && filtered_rural_other.h3_index
-    WHERE l.actual_property_use = '00'
+    WHERE l.actual_property_use = '00' -- 0.0 Multi-use at primary level
 
     UNION ALL
 

--- a/classifications/nzlum/classes/class_310.sql
+++ b/classifications/nzlum/classes/class_310.sql
@@ -56,12 +56,33 @@ CREATE TEMPORARY VIEW class_310 AS ( -- Residential
                 WHEN topo50_residential_areas_h3.h3_index IS NOT NULL
                 THEN -1
                 ELSE 0
+            END
+            +
+            CASE -- Properties larger than lifestyle size (>2ha) are likely non-residential (→ 2.x or 1.x)
+                WHEN over_sized_for_lifestyle THEN 6
+                ELSE 0
+            END
+            +
+            CASE -- LCDB cropland/arable land cover contradicts residential use
+                WHEN lcdb_cropland.h3_index IS NOT NULL THEN 4
+                ELSE 0
+            END
+            +
+            CASE -- Industrial zoning strongly contradicts residential use
+                WHEN linz_dvr_.zone ~ '^7' THEN 5
+                ELSE 0
             END, 12), 1),
             ARRAY[]::TEXT[],
             ARRAY[]::TEXT[],
-            ARRAY[linz_dvr_.source_data]::TEXT[],
-            linz_dvr_.source_date,
-            linz_dvr_.source_scale,
+            ARRAY[linz_dvr_.source_data, lcdb_cropland.source_data]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                linz_dvr_.source_date,
+                lcdb_cropland.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                linz_dvr_.source_scale,
+                lcdb_cropland.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type
         WHEN (
@@ -73,12 +94,26 @@ CREATE TEMPORARY VIEW class_310 AS ( -- Residential
             )
         THEN ROW(
             ARRAY[]::TEXT[], -- lu_code_ancillary,
-            8,
+            LEAST(12, 8 + CASE
+                WHEN lcdb_cropland.h3_index IS NOT NULL THEN 4 -- LCDB cropland/arable contradicts residential use
+                ELSE 0
+            END + CASE -- Industrial zoning strongly contradicts residential use
+                WHEN linz_dvr_.zone ~ '^7' THEN 5
+                ELSE 0
+            END),
             ARRAY[]::TEXT[],
             ARRAY[]::TEXT[],
-            ARRAY[irrigation_.source_data, linz_dvr_.source_data]::TEXT[],
-            range_merge(irrigation_.source_date,linz_dvr_.source_date),
-            range_merge(irrigation_.source_scale,linz_dvr_.source_scale),
+            ARRAY[irrigation_.source_data, linz_dvr_.source_data, lcdb_cropland.source_data]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                irrigation_.source_date,
+                linz_dvr_.source_date,
+                lcdb_cropland.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                irrigation_.source_scale,
+                linz_dvr_.source_scale,
+                lcdb_cropland.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type
         ELSE NULL
@@ -92,8 +127,10 @@ CREATE TEMPORARY VIEW class_310 AS ( -- Residential
             source_scale,
             actual_property_use,
             category,
+            "zone",
             improvements_value,
-            gt_half_acre
+            gt_half_acre,
+            over_sized_for_lifestyle
         FROM linz_dvr_
         WHERE (
             actual_property_use ~ '^9' -- Residential
@@ -125,5 +162,15 @@ CREATE TEMPORARY VIEW class_310 AS ( -- Residential
         FROM topo50_residential_areas_h3
         WHERE :parent::h3index = h3_partition
     ) AS topo50_residential_areas_h3 ON roi.h3_index && topo50_residential_areas_h3.h3_index
+    LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale
+        FROM lcdb_
+        WHERE
+            :parent::h3index = h3_partition
+            AND Class_2018 IN (
+                30, -- Short-rotation Cropland
+                33  -- Orchards, Vineyards or Other Perennial Crops
+            )
+    ) AS lcdb_cropland ON roi.h3_index && lcdb_cropland.h3_index
     WHERE linz_dvr_.h3_index IS NOT NULL OR hnz.h3_index IS NOT NULL
 );

--- a/classifications/nzlum/classes/class_330.sql
+++ b/classifications/nzlum/classes/class_330.sql
@@ -18,7 +18,7 @@ CREATE TEMPORARY VIEW class_330 AS ( -- Commercial: retail, office, hospitality,
         WHEN dvr_commercial.h3_index IS NOT NULL
         THEN ROW(
             ARRAY[]::TEXT[], -- lu_code_ancillary
-            CASE
+            clamp_confidence_or_null(CASE
                 WHEN
                     dvr_commercial.actual_property_use NOT IN (
                         '08',  -- Multi-use within commercial
@@ -27,7 +27,7 @@ CREATE TEMPORARY VIEW class_330 AS ( -- Commercial: retail, office, hospitality,
                     )
                     AND dvr_commercial.improvements_value > 0
                 THEN 1
-                WHEN 
+                WHEN
                     dvr_commercial.actual_property_use IN (
                         '08',  -- Multi-use within commercial
                         '78' -- Industrial, depots and yards
@@ -39,7 +39,7 @@ CREATE TEMPORARY VIEW class_330 AS ( -- Commercial: retail, office, hospitality,
                     ELSE 4
                 END
                 WHEN (
-                    dvr_commercial.actual_property_use IS NULL 
+                    dvr_commercial.actual_property_use IS NULL
                     AND dvr_commercial.category ~ '^C'
                 )
                 THEN 9
@@ -52,7 +52,11 @@ CREATE TEMPORARY VIEW class_330 AS ( -- Commercial: retail, office, hospitality,
                 WHEN dvr_commercial.category ~ '^C'
                 THEN 10
                 ELSE NULL
-            END,
+            END
+            + CASE -- Industrial zoning suggests commercial use is less certain
+                WHEN dvr_commercial.zone ~ '^7' THEN 2
+                ELSE 0
+            END),
             ARRAY[]::TEXT[],
             ARRAY[]::TEXT[],
             ARRAY[dvr_commercial.source_data]::TEXT[],
@@ -70,6 +74,7 @@ CREATE TEMPORARY VIEW class_330 AS ( -- Commercial: retail, office, hospitality,
             source_scale,
             actual_property_use,
             category,
+            "zone",
             improvements_value,
             improvements_description
         FROM linz_dvr_

--- a/classifications/nzlum/classes/class_340.sql
+++ b/classifications/nzlum/classes/class_340.sql
@@ -8,7 +8,7 @@ CREATE TEMPORARY VIEW class_340 AS ( -- Manufacturing and industrial
         CASE
             WHEN linz_dvr_industrial.h3_index IS NOT NULL
             THEN
-                LEAST(GREATEST(CASE
+                clamp_confidence_or_null(CASE
                     WHEN
                         actual_property_use <> '07'
                         AND actual_property_use NOT LIKE '%0'
@@ -41,7 +41,7 @@ CREATE TEMPORARY VIEW class_340 AS ( -- Manufacturing and industrial
                     WHEN hail_manufacturing_and_industrial.h3_index IS NOT NULL
                     THEN -1
                     ELSE 0
-                END, 1), 12)
+                END)
             WHEN  hail_manufacturing_and_industrial.h3_index IS NOT NULL
             THEN 12 -- Residual possibility
             ELSE NULL

--- a/classifications/nzlum/classes/class_390.sql
+++ b/classifications/nzlum/classes/class_390.sql
@@ -14,23 +14,54 @@ CREATE TEMPORARY VIEW class_390 AS (
     9 AS lu_code_secondary,
     0 AS lu_code_tertiary,
     CASE
-        WHEN 
+        WHEN
             transitional_land.h3_index IS NOT NULL
             AND urban_rural_current_.h3_index IS NOT NULL
         THEN CASE
             WHEN linz_dvr_full_.h3_index IS NULL
             THEN ROW(
                 ARRAY[]::TEXT[], -- lu_code_ancillary
-                1,
+                LEAST(12, 1 + CASE
+                    WHEN lcdb_horticulture.h3_index IS NOT NULL THEN 4 -- LCDB shows active cropland/horticulture; contradicts vacant classification
+                    ELSE 0
+                END),
                 ARRAY[]::TEXT[], -- commod
                 ARRAY[]::TEXT[], -- manage
-                ARRAY[transitional_land.source_data]::TEXT[],
-                transitional_land.source_date,
-                transitional_land.source_scale,
+                ARRAY[transitional_land.source_data, lcdb_horticulture.source_data]::TEXT[],
+                range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                    transitional_land.source_date,
+                    lcdb_horticulture.source_date
+                ], NULL))),
+                range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                    transitional_land.source_scale,
+                    lcdb_horticulture.source_scale
+                ], NULL))),
+                NULL
+            )::nzlum_type
+            WHEN linz_dvr_full_.actual_property_use = '29' -- Lifestyle: vacant (less certain — lifestyle blocks are often not truly transitioning)
+            THEN ROW(
+                ARRAY[]::TEXT[], -- lu_code_ancillary
+                LEAST(12, 4 + CASE
+                    WHEN lcdb_horticulture.h3_index IS NOT NULL THEN 4 -- LCDB shows active cropland/horticulture; contradicts vacant classification
+                    ELSE 0
+                END),
+                ARRAY[]::TEXT[], -- commod
+                ARRAY[]::TEXT[], -- manage
+                ARRAY[transitional_land.source_data, linz_dvr_full_.source_data, lcdb_horticulture.source_data]::TEXT[],
+                range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                    transitional_land.source_date,
+                    linz_dvr_full_.source_date,
+                    lcdb_horticulture.source_date
+                ], NULL))),
+                range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                    transitional_land.source_scale,
+                    linz_dvr_full_.source_scale,
+                    lcdb_horticulture.source_scale
+                ], NULL))),
                 NULL
             )::nzlum_type
             WHEN (
-                linz_dvr_full_.actual_property_use ~ '[1-9]9$' -- Vacant
+                linz_dvr_full_.actual_property_use ~ '[13-9]9$' -- Vacant (built-environment or rural-industry codes)
                 OR linz_dvr_full_.actual_property_use IN (
                     '00', -- Vacant
                     '55' -- Passive outdoor
@@ -39,40 +70,56 @@ CREATE TEMPORARY VIEW class_390 AS (
             )
             THEN ROW(
                 ARRAY[]::TEXT[], -- lu_code_ancillary
-                1,
+                LEAST(12, 1 + CASE
+                    WHEN lcdb_horticulture.h3_index IS NOT NULL THEN 4 -- LCDB shows active cropland/horticulture; contradicts vacant classification
+                    ELSE 0
+                END),
                 ARRAY[]::TEXT[], -- commod
                 ARRAY[]::TEXT[], -- manage
-                ARRAY[transitional_land.source_data, linz_dvr_full_.source_data]::TEXT[],
-                range_merge(transitional_land.source_date, linz_dvr_full_.source_date),
-                range_merge(transitional_land.source_scale, linz_dvr_full_.source_scale),
+                ARRAY[transitional_land.source_data, linz_dvr_full_.source_data, lcdb_horticulture.source_data]::TEXT[],
+                range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                    transitional_land.source_date,
+                    linz_dvr_full_.source_date,
+                    lcdb_horticulture.source_date
+                ], NULL))),
+                range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                    transitional_land.source_scale,
+                    linz_dvr_full_.source_scale,
+                    lcdb_horticulture.source_scale
+                ], NULL))),
                 NULL
             )::nzlum_type
             WHEN linz_dvr_full_.category ~ '\wV'
             THEN ROW(
                 ARRAY[]::TEXT[], -- lu_code_ancillary
-                CASE
+                LEAST(12, CASE
                     WHEN linz_dvr_full_.zone ~ '^[789]' -- Higher confidence when also zoned for industrial, commercial, residential
                     THEN 8
                     ELSE 10
-                END,
+                END + CASE
+                    WHEN lcdb_horticulture.h3_index IS NOT NULL THEN 4 -- LCDB shows active cropland/horticulture; contradicts vacant classification
+                    ELSE 0
+                END),
                 ARRAY[]::TEXT[], -- commod
                 ARRAY[]::TEXT[], -- manage
-                ARRAY[transitional_land.source_data, linz_dvr_full_.source_data]::TEXT[],
-                range_merge(
+                ARRAY[transitional_land.source_data, linz_dvr_full_.source_data, lcdb_horticulture.source_data]::TEXT[],
+                range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
                     transitional_land.source_date,
-                    linz_dvr_full_.source_date
-                ),
-                range_merge(
+                    linz_dvr_full_.source_date,
+                    lcdb_horticulture.source_date
+                ], NULL))),
+                range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
                     transitional_land.source_scale,
-                    linz_dvr_full_.source_scale
-                ),
+                    linz_dvr_full_.source_scale,
+                    lcdb_horticulture.source_scale
+                ], NULL))),
                 NULL
             )::nzlum_type
             END
         WHEN linz_dvr_vacant_built.h3_index IS NOT NULL
         THEN ROW(
             ARRAY[]::TEXT[], -- lu_code_ancillary
-            CASE
+            clamp_confidence_or_null(CASE
                 WHEN linz_dvr_vacant_built.actual_property_use IN (
                     '39', -- Transport: vacant
                     '49', -- Community services: vacant
@@ -80,7 +127,7 @@ CREATE TEMPORARY VIEW class_390 AS (
                     '69', -- Utility services: vacant
                     '79', -- Industrial: vacant
                     '89', -- Commercial: vacant
-                    '99' -- Residetial: vacant
+                    '99' -- Residential: vacant
                 )
                 THEN
                     CASE
@@ -90,15 +137,22 @@ CREATE TEMPORARY VIEW class_390 AS (
                         THEN 2
                         ELSE 5
                     END
-                WHEN linz_dvr_vacant_built.actual_property_use IN (
-                    '00', -- Multi-use at primary level: Vacant or intermediate
-                    '29' -- Lifestyle: vacant
-                ) THEN
+                WHEN linz_dvr_vacant_built.actual_property_use = '00' -- Multi-use at primary level: Vacant or intermediate
+                THEN
                     CASE
                         WHEN linz_dvr_vacant_built.zone ~ '^[24789].*' AND low_ratio_improvements
                         THEN 3
                         WHEN linz_dvr_vacant_built.zone ~ '^[24789].*'
                         THEN 4
+                        ELSE NULL
+                    END
+                WHEN linz_dvr_vacant_built.actual_property_use = '29' -- Lifestyle: vacant (less certain — lifestyle blocks are often not truly transitioning)
+                THEN
+                    CASE
+                        WHEN linz_dvr_vacant_built.zone ~ '^[24789].*' AND low_ratio_improvements
+                        THEN 5
+                        WHEN linz_dvr_vacant_built.zone ~ '^[24789].*'
+                        THEN 6
                         ELSE NULL
                     END
                 WHEN (
@@ -116,12 +170,33 @@ CREATE TEMPORARY VIEW class_390 AS (
                         THEN 2
                         ELSE 5
                     END
-            END, -- confidence
+            END
+            + CASE -- Penalise by valuation recency: older vacancy records are less reliable
+                WHEN linz_dvr_vacant_built.current_effective_valuation_date IS NULL
+                THEN 2
+                WHEN linz_dvr_vacant_built.current_effective_valuation_date > CURRENT_DATE - INTERVAL '1 year'
+                THEN 0
+                WHEN linz_dvr_vacant_built.current_effective_valuation_date > CURRENT_DATE - INTERVAL '3 years'
+                THEN 1
+                WHEN linz_dvr_vacant_built.current_effective_valuation_date > CURRENT_DATE - INTERVAL '5 years'
+                THEN 2
+                ELSE 3
+            END
+            + CASE -- LCDB horticulture signal contradicts a vacant/transitioning classification
+                WHEN lcdb_horticulture.h3_index IS NOT NULL THEN 4 -- Short-rotation cropland or orchards/vineyards/perennial crops
+                ELSE 0
+            END), -- confidence
             ARRAY[]::TEXT[], -- commod
             ARRAY[]::TEXT[], -- manage
-            ARRAY[linz_dvr_vacant_built.source_data]::TEXT[],
-            linz_dvr_vacant_built.source_date,
-            linz_dvr_vacant_built.source_scale,
+            ARRAY[linz_dvr_vacant_built.source_data, lcdb_horticulture.source_data]::TEXT[],
+            range_merge(datemultirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                linz_dvr_vacant_built.source_date,
+                lcdb_horticulture.source_date
+            ], NULL))),
+            range_merge(int4multirange(VARIADIC ARRAY_REMOVE(ARRAY[
+                linz_dvr_vacant_built.source_scale,
+                lcdb_horticulture.source_scale
+            ], NULL))),
             NULL
         )::nzlum_type
     END AS nzlum_type
@@ -132,6 +207,7 @@ CREATE TEMPORARY VIEW class_390 AS (
             source_data,
             source_date,
             source_scale,
+            current_effective_valuation_date,
             actual_property_use,
             category,
             "zone",
@@ -182,6 +258,16 @@ CREATE TEMPORARY VIEW class_390 AS (
             :parent::h3index = h3_partition
             AND urban_rural_current.IUR2026_V1_00 <> '22' -- (non) "Rural other"
     ) AS urban_rural_current_ ON roi.h3_index && urban_rural_current_.h3_index
+    LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale
+        FROM lcdb_
+        WHERE
+            :parent::h3index = h3_partition
+            AND Class_2018 IN (
+                30, -- Short-rotation Cropland
+                33  -- Orchards, Vineyards or Other Perennial Crops
+            )
+    ) AS lcdb_horticulture ON roi.h3_index && lcdb_horticulture.h3_index
     LEFT JOIN water_features ON roi.h3_index && water_features.h3_index
     LEFT JOIN pan_nz_draft_h3 ON roi.h3_index && pan_nz_draft_h3.h3_index
     WHERE (transitional_land.h3_index IS NOT NULL OR linz_dvr_vacant_built.h3_index IS NOT NULL)

--- a/classifications/nzlum/data_views/irrigation.sql
+++ b/classifications/nzlum/data_views/irrigation.sql
@@ -36,7 +36,8 @@ CREATE TEMPORARY VIEW irrigation_ AS (
                 )
                 THEN 'irrigation drip'
                 ELSE 'irrigation'
-            END AS manage
+            END AS manage,
+            irrigation_2020.irrigation_age
     FROM irrigation_2020_h3
     INNER JOIN irrigation_2020 USING (ogc_fid)
     WHERE :parent::h3index = h3_partition
@@ -69,7 +70,8 @@ CREATE TEMPORARY VIEW irrigation_ AS (
             source_date,
             source_data,
             source_scale,
-            'irrigation'::TEXT AS manage
+            'irrigation'::TEXT AS manage,
+            NULL::int AS irrigation_age
         FROM ecan_consented_activities_areas_active
         JOIN ecan_consented_activities_areas_active_h3 USING (ogc_fid)
         WHERE :parent::h3index = h3_partition

--- a/classifications/nzlum/data_views/linz_crosl.sql
+++ b/classifications/nzlum/data_views/linz_crosl.sql
@@ -3,7 +3,7 @@ CREATE TEMPORARY VIEW linz_crosl_ AS (
     h3_finest(crosl_.h3_index, urban_rural_current_.h3_index) AS h3_index,
     managed_by, -- e.g. "Housing New Zealand"
     statutory_actions,
-    area_ha,
+    area AS area_ha,
     'LINZ CRoSL' AS source_data,
     daterange(
         LEAST(

--- a/classifications/nzlum/data_views/linz_dvr.sql
+++ b/classifications/nzlum/data_views/linz_dvr.sql
@@ -6,6 +6,8 @@ CREATE TEMPORARY VIEW linz_dvr_ AS (
     improvements_value_ratio,
     legal_description,
     gt_half_acre,
+    sized_for_lifestyle,
+    over_sized_for_lifestyle,
     land_area,
     property_category as category,
     actual_property_use,
@@ -14,6 +16,7 @@ CREATE TEMPORARY VIEW linz_dvr_ AS (
         current_effective_valuation_date::DATE,
         '[]'::TEXT
     ) AS source_date,
+    current_effective_valuation_date,
     improvements_description,
     ts_improvements_description,
     zoning AS "zone",

--- a/classifications/nzlum/nzlum-preclassify.sql
+++ b/classifications/nzlum/nzlum-preclassify.sql
@@ -261,5 +261,5 @@ RETURNS int4range AS \$\$
 -- Clamp to 1 to 12 range, but don't clamp values over 12, exclude them instead
 CREATE OR REPLACE FUNCTION clamp_confidence_or_null(confidence numeric)
 RETURNS numeric AS \$\$
-  SELECT CASE WHEN confidence > 12 THEN NULL ELSE GREATEST(confidence, 1) END;
+  SELECT CASE WHEN confidence IS NULL OR confidence > 12 THEN NULL ELSE GREATEST(confidence, 1) END;
 \$\$ LANGUAGE SQL IMMUTABLE;

--- a/external-data/linz/nz_properties.yml
+++ b/external-data/linz/nz_properties.yml
@@ -48,10 +48,24 @@ external_data:
         type: btree
         name: idx_btree_partial_gt_half_acre
         where: gt_half_acre = TRUE
+      - columns: [over_sized_for_lifestyle]
+        type: btree
+        name: idx_btree_partial_over_sized_for_lifestyle
+        where: over_sized_for_lifestyle = TRUE
+      - columns: [sized_for_lifestyle]
+        type: btree
+        name: idx_btree_partial_sized_for_lifestyle
+        where: sized_for_lifestyle = TRUE
     derived_columns: # Is geometry greater than half an acre?
       - column: gt_half_acre
         datatype: boolean
         set_query: st_area(geom::geography) > 2023.43
+      - column: over_sized_for_lifestyle # as per 3.1.4 https://nzlum.landcareresearch.co.nz/classification/v0-4/classes/300/#310-residential
+        datatype: boolean
+        set_query: st_area(geom::geography) > 20000
+      - column: sized_for_lifestyle
+        datatype: boolean
+        set_query: st_area(geom::geography) <= 20000 AND st_area(geom::geography) > 4000
 
   
   national_dvr:

--- a/external-data/mfe/mfe.yml
+++ b/external-data/mfe/mfe.yml
@@ -38,6 +38,9 @@ external_data:
       - column: ts_notes
         datatype: tsvector
         set_query: to_tsvector('english', notes)
+      - column: irrigation_age
+        datatype: int
+        set_query: EXTRACT(YEAR FROM CURRENT_DATE)::int - year_irr
     indices:
       - columns: [is_current]
         type: btree
@@ -57,6 +60,9 @@ external_data:
       - columns: [ts_notes]
         type: gin
         name: idx_gin_ts_notes
+      - columns: [irrigation_age]
+        type: btree
+        name: idx_btree_irrigation_age
   lum:
     <<: *mfe
     description: LUCAS NZ Land Use Map 2020 v003


### PR DESCRIPTION
Bug fix — `clamp_confidence_or_null(NULL)` returned `1` instead of `NULL` (PostgreSQL `GREATEST(NULL, 1) = 1`). Fixed with explicit `IS NULL` guard. Affected classes 117, 230, 340, 390 — `ELSE NULL` branches were silently producing the highest confidence.

**This was quite an influential bug and fixing it has resolved a wide-ranging set of misclassifications and improved the classification measurably.** This alone addressed the major problems noticed by Linda in #6. However further adjustments were made to make thematic improvements as suggested.

Irrigation recency — age penalty applied in classes 230/240/250; irrigation_age formula corrected in mfe.yml (was hardcoded 2020).

Drip/non-drip split — drip excluded from class_230 (short-rotation); classes 240/250 now only admit drip as irrigation signal.

Vacant lifestyle confidence — APU=29 separated from APU=00 in class_390 (confidence 5/6 not 3/4); current_effective_valuation_date now used to scale confidence by recency in both class_390 and class_280_v2.

LCDB horticulture penalty — LCDB 30/33 adds +4 penalty in class_390 (active cropland/orchards contradict vacant classification).

Industrial zone penalties — +5 in class_310 (residential), +2 in class_330 (commercial).

Closes #6 