### PR TITLE
Add GWRC managed plantation forests to class_210

### DIFF
--- a/classifications/nzlum/classes/class_210.sql
+++ b/classifications/nzlum/classes/class_210.sql
@@ -3,7 +3,18 @@ CREATE TEMPORARY VIEW class_210 AS ( -- Plantation forests
     2 AS lu_code_primary,
     1 AS lu_code_secondary,
     0 AS lu_code_tertiary,
-    CASE 
+    CASE
+        WHEN gwrc_.h3_index IS NOT NULL
+        THEN ROW(
+            ARRAY[]::TEXT[], -- lu_code_ancillary
+            1, -- confidence
+            ARRAY[]::TEXT[], -- commod
+            ARRAY[]::TEXT[], -- manage
+            ARRAY[gwrc_.source_data]::TEXT[], -- source_data
+            gwrc_.source_date, -- source_date
+            gwrc_.source_scale, -- source_scale
+            gwrc_.comment -- comment
+        )::nzlum_type
         WHEN (
             lum_.subid_2020 = '122 - Wilding trees'
             AND topo50_exotic_polygons_.h3_index IS NOT NULL
@@ -124,6 +135,10 @@ CREATE TEMPORARY VIEW class_210 AS ( -- Plantation forests
     -- species (topo50: empty=coniferous, and "non-coniferous")
     FROM roi
     LEFT JOIN (
+        SELECT h3_index, species_clean, source_data, source_date, source_scale, comment
+        FROM gwrc_plantation_forests_
+    ) AS gwrc_ ON roi.h3_index && gwrc_.h3_index
+    LEFT JOIN (
         SELECT
             h3_index,
             source_data,
@@ -189,7 +204,8 @@ CREATE TEMPORARY VIEW class_210 AS ( -- Plantation forests
             '33' -- Oceanic
         )
     ) AS rural ON roi.h3_index && rural.h3_index
-    WHERE lum_.h3_index IS NOT NULL
+    WHERE gwrc_.h3_index IS NOT NULL
+       OR lum_.h3_index IS NOT NULL
        OR topo50_exotic_polygons_.h3_index IS NOT NULL
        OR consents_forestry.h3_index IS NOT NULL
 );

--- a/classifications/nzlum/config.nzlum.yml
+++ b/classifications/nzlum/config.nzlum.yml
@@ -110,6 +110,9 @@ classifications:
       
       - es_slu
       - es_winter_forage_2017
+
+      - gwrc_plantation_forests_western
+      - gwrc_plantation_forests_eastern
     table_schema:
       unit_id: BIGINT
       lu_code_primary: INTEGER

--- a/classifications/nzlum/data_views/gwrc_plantation_forests.sql
+++ b/classifications/nzlum/data_views/gwrc_plantation_forests.sql
@@ -1,0 +1,46 @@
+CREATE TEMPORARY VIEW gwrc_plantation_forests_ AS
+SELECT
+    h3.h3_index,
+    gwrc.species_clean,
+    'GWRC' AS source_data,
+    DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+    '[10,20]'::int4range AS source_scale,
+    NULLIF(ARRAY_TO_STRING(
+        ARRAY_REMOVE(
+            ARRAY[
+                CASE WHEN gwrc.year_planted_clean IS NOT NULL
+                     THEN 'planted:' || gwrc.year_planted_clean::text END
+            ] || COALESCE(
+                ARRAY(SELECT 'species:' || s FROM unnest(gwrc.species_clean) s),
+                ARRAY[]::text[]
+            ),
+            NULL
+        ), E'\n'
+    ), '') AS comment
+FROM gwrc_plantation_forests_western gwrc
+INNER JOIN gwrc_plantation_forests_western_h3 h3 USING (ogc_fid)
+WHERE :parent::h3index = h3.h3_partition
+
+UNION ALL
+
+SELECT
+    h3.h3_index,
+    gwrc.species_clean,
+    'GWRC' AS source_data,
+    DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+    '[10,20]'::int4range AS source_scale,
+    NULLIF(ARRAY_TO_STRING(
+        ARRAY_REMOVE(
+            ARRAY[
+                CASE WHEN gwrc.year_planted_clean IS NOT NULL
+                     THEN 'planted:' || gwrc.year_planted_clean::text END
+            ] || COALESCE(
+                ARRAY(SELECT 'species:' || s FROM unnest(gwrc.species_clean) s),
+                ARRAY[]::text[]
+            ),
+            NULL
+        ), E'\n'
+    ), '') AS comment
+FROM gwrc_plantation_forests_eastern gwrc
+INNER JOIN gwrc_plantation_forests_eastern_h3 h3 USING (ogc_fid)
+WHERE :parent::h3index = h3.h3_partition;

--- a/classifications/nzlum/nzlum.sql
+++ b/classifications/nzlum/nzlum.sql
@@ -32,6 +32,7 @@ CREATE TEMPORARY VIEW roi AS (
 \ir data_views/consents/dairy_effluent_discharge.sql
 \ir data_views/consents/forestry.sql
 \ir data_views/consents/pastoral_farms.sql
+\ir data_views/gwrc_plantation_forests.sql
 
 -- attributes
 \ir attributes/water.sql

--- a/external-data/regional-govt/gwrc.yml
+++ b/external-data/regional-govt/gwrc.yml
@@ -2,3 +2,63 @@
 # https://catalogue.data.govt.nz/dataset/water-collection-areas (status = current) -- but this is CC BY-ND 4.0
 # See also https://catalogue.data.govt.nz/dataset/water-course/resource/e4f3d315-7589-4ff9-921d-eb881fda51ce
 
+__gwrc__: &gwrc
+  external_data_type: arcgis_rest
+  license: CC BY 4.0
+  attribution: Greater Wellington Regional Council
+
+external_data:
+  gwrc_plantation_forests_western: &gwrc_plantation_forests_western
+    <<: *gwrc
+    host: https://mapping.gw.govt.nz/arcgis/rest/services/GW/Parks_P/MapServer
+    description: Western Area Managed Plantation Forests
+    geom_type: multipolygon
+    layer: "16"
+    derived_columns:
+      - column: species_clean
+        datatype: text[]
+        set_query: |-
+          NULLIF(
+            ARRAY_REMOVE(
+              ARRAY(
+                SELECT CASE
+                  WHEN token ~* 'P[\s\.]+rad'
+                    THEN 'Pinus radiata'
+                  WHEN token ~* 'C[\s\.]+mac'
+                    THEN 'Cupressus macrocarpa'
+                  WHEN token ~* 'Ps\.menz?'
+                    THEN 'Pseudotsuga menziesii'
+                  WHEN token ~* 'P\.contorta'
+                    THEN 'Pinus contorta'
+                  WHEN token ~* 'P\.nigra'
+                    THEN 'Pinus nigra'
+                  WHEN token ~* 'Euc(?:alypt(?:us)?)?\s*[.\s]spp'
+                    THEN 'Eucalyptus spp.'
+                  WHEN token ~* 'Acc?acia\s+mel'
+                    THEN 'Acacia melanoxylon'
+                  WHEN token ~* 'Pop'
+                    THEN 'Populus spp.'
+                  ELSE NULL
+                END
+                FROM unnest(regexp_split_to_array(species, '\s*/\s*')) AS token
+              ),
+              NULL
+            ),
+            ARRAY[]::text[]
+          )
+      - column: year_planted_clean
+        datatype: integer
+        set_query: |-
+          (regexp_match(year_planted::text, '\d{4}'))[1]::integer
+    indices:
+      - columns: [species_clean]
+        type: gin
+        name: idx_gin_species_clean
+      - columns: [year_planted_clean]
+        type: btree
+        name: idx_year_planted_clean
+        
+  gwrc_plantation_forests_eastern:
+    <<: *gwrc_plantation_forests_western
+    layer: "15"
+    description: Eastern Area Managed Plantation Forests

--- a/profiles/nzlum/config.yaml
+++ b/profiles/nzlum/config.yaml
@@ -17,7 +17,7 @@ configfiles:
 
   - luis-config-nzlum/external-data/regional-govt/ecan.yml
   - luis-config-nzlum/external-data/regional-govt/gdc.yml
-  # - luis-config-nzlum/external-data/regional-govt/gwrc.yml
+  - luis-config-nzlum/external-data/regional-govt/gwrc.yml
   - luis-config-nzlum/external-data/regional-govt/hbrc.yml
   - luis-config-nzlum/external-data/regional-govt/horizons.yml
   - luis-config-nzlum/external-data/regional-govt/es.yml


### PR DESCRIPTION
- Add gwrc.yml with western (layer 16) and eastern (layer 15) managed plantation forest polygons from the GWRC ArcGIS REST service
- Derive species_clean (text[], regex-mapped to Latin names, GIN indexed) and year_planted_clean (integer, btree indexed) at import time
- Enable gwrc.yml in profiles/nzlum/config.yaml and register both datasets in config.nzlum.yml
- New data view gwrc_plantation_forests_ unions both datasets, computing a comment string (planted:{year}, species:{name} lines) at view time
- GWRC cells classified as confidence=1 in class_210, taking priority over all other plantation forest evidence; species and year surfaced in the comment field

Closes #3 