### PR TITLE
refines horse-related intensive/extensive 2.2.0/2.6.0, closes #10

### DIFF
--- a/classifications/nzlum/classes/class_220.sql
+++ b/classifications/nzlum/classes/class_220.sql
@@ -69,13 +69,21 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                 )
                 THEN 8
 
+                -- Horse studs: disambiguate by training track presence and property size
+                WHEN linz_dvr_.category ~ '^SH'
+                THEN CASE
+                    WHEN horse_training_properties_.h3_index IS NOT NULL THEN NULL -- intensive; let class_260 claim
+                    WHEN linz_dvr_.land_area > 20 THEN 8 -- extensive-sized, plausibly pastoral
+                    ELSE 11
+                END
+
                 WHEN (
                         linz_dvr_.actual_property_use IN (
                         '15', -- Market gardens and orchards
                         '17', -- Forestry
                         '18' -- Mineral extraction
                     )
-                    OR linz_dvr_.category ~ '^(LI|SD|SH|SX)'
+                    OR linz_dvr_.category ~ '^(LI|SD|SX)'
                     OR winter_forage_.h3_index IS NOT NULL
                 )
                 THEN 11
@@ -181,7 +189,8 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                 nzlri_lowcapability.source_data,
                 consents_forestry.source_data,
                 pasture_practices.source_data,
-                pastoral_consents.source_data
+                pastoral_consents.source_data,
+                horse_training_properties_.source_data
             ]::TEXT[], -- source_data
             range_merge(datemultirange(
                 VARIADIC ARRAY_REMOVE(ARRAY[
@@ -194,7 +203,8 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                     nzlri_lowcapability.source_date,
                     consents_forestry.source_date,
                     pasture_practices.source_date,
-                    pastoral_consents.source_date
+                    pastoral_consents.source_date,
+                    horse_training_properties_.source_date
                 ], NULL)
             ))::daterange, -- source_date
             range_merge(int4multirange(
@@ -208,10 +218,18 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                     nzlri_lowcapability.source_scale,
                     consents_forestry.source_scale,
                     pasture_practices.source_scale,
-                    pastoral_consents.source_scale
+                    pastoral_consents.source_scale,
+                    horse_training_properties_.source_scale
                 ], NULL)
             ))::int4range, -- source_scale
-            NULL
+            NULLIF(CONCAT_WS(E'\n',
+                CASE WHEN linz_dvr_.category ~ '^SH' AND horse_training_properties_.h3_index IS NOT NULL
+                     THEN 'horse training track (topo50)' END,
+                CASE WHEN linz_dvr_.category ~ '^SH' AND linz_dvr_.improvements_description ~ '\m(STABLES?)\M'
+                     THEN 'stables' END,
+                CASE WHEN linz_dvr_.category ~ '^SH' AND linz_dvr_.improvements_description ~ '\m(EQUES|EQUESTRIAN)\s?(CTR|CENTER|CENTRE)?\M'
+                     THEN 'equestrian centre' END
+            ), '') -- comment
         )::nzlum_type AS nzlum_type
         FROM roi
         LEFT JOIN (
@@ -222,7 +240,8 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                 source_scale,
                 improvements_description,
                 actual_property_use,
-                category
+                category,
+                land_area
             FROM linz_dvr_
             WHERE linz_dvr_.actual_property_use ~ '^1' -- Rural industry
             OR linz_dvr_.actual_property_use = '01' -- Multi-use at primary level, rural-industry
@@ -348,6 +367,10 @@ CREATE TEMPORARY VIEW class_220 AS ( -- Grazing modified pasture systems
                 ]
             )
         ) AS pasture_practices ON roi.h3_index && pasture_practices.h3_index
+        LEFT JOIN (
+            SELECT h3_index, source_data, source_date, source_scale
+            FROM horse_training_properties_
+        ) AS horse_training_properties_ ON roi.h3_index && horse_training_properties_.h3_index
         WHERE lum_.h3_index IS NOT NULL
            OR linz_dvr_.h3_index IS NOT NULL
            OR lcdb_.h3_index IS NOT NULL

--- a/classifications/nzlum/classes/class_260.sql
+++ b/classifications/nzlum/classes/class_260.sql
@@ -25,6 +25,8 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
         THEN ROW(
             ARRAY[]::TEXT[], -- lu_code_ancillary
             CASE
+                WHEN linz_dvr_.category ~ '^SH' AND horse_training_properties_.h3_index IS NOT NULL
+                THEN 2 -- Confirmed horse training property (topo50 track)
                 WHEN (
                     linz_dvr_.improvements_description ~ '\m(ANML|ANIMAL)\s?(SHLTR|SHELTER)S?\M'
                     OR linz_dvr_.improvements_description ~ '\m(STABLE|KENNEL)S?\M'
@@ -36,6 +38,8 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
                     OR linz_dvr_.improvements_description ~ '\mEGG\sLAYING\M'
                 )
                 THEN 3
+                WHEN horse_training_properties_.h3_index IS NOT NULL
+                THEN 4 -- Possible horse training property
                 WHEN linz_dvr_.category ~ '[AB]$'
                 THEN 4 -- Higher confidence if a more economically viable property
                 WHEN linz_dvr_.category ~ '[C]$'
@@ -60,10 +64,27 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
                 END
             ]::TEXT[], -- commod
             ARRAY[]::TEXT[], -- manage
-            ARRAY[linz_dvr_.source_data]::TEXT[],
-            linz_dvr_.source_date,
-            linz_dvr_.source_scale,
-            NULL
+            ARRAY[linz_dvr_.source_data, horse_training_properties_.source_data]::TEXT[],
+            range_merge(datemultirange(
+                VARIADIC ARRAY_REMOVE(ARRAY[
+                    linz_dvr_.source_date,
+                    horse_training_properties_.source_date
+                ], NULL)
+            ))::daterange,
+            range_merge(int4multirange(
+                VARIADIC ARRAY_REMOVE(ARRAY[
+                    linz_dvr_.source_scale,
+                    horse_training_properties_.source_scale
+                ], NULL)
+            ))::int4range,
+            NULLIF(CONCAT_WS(E'\n',
+                CASE WHEN horse_training_properties_.h3_index IS NOT NULL
+                     THEN 'Horse training track' END,
+                CASE WHEN linz_dvr_.improvements_description ~ '\m(STABLES?)\M'
+                     THEN 'Stables' END,
+                CASE WHEN linz_dvr_.improvements_description ~ '\m(EQUES|EQUESTRIAN)\s?(CTR|CENTER|CENTRE)?\M'
+                     THEN 'Equestrian centre' END
+            ), '') -- comment
         )::nzlum_type
         ELSE NULL
     END AS nzlum_type
@@ -84,5 +105,9 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
         OR category ~ '^S(A|H|P|S|X)' -- Specialist types except deer: aquaculture, horse studs and training operations, poultry, pigs, all other specialist livestock
         OR actual_property_use IN ('0', '00', '01', '1', '10', '16')
     ) linz_dvr_ ON roi.h3_index && linz_dvr_.h3_index
+    LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale
+        FROM horse_training_properties_
+    ) AS horse_training_properties_ ON roi.h3_index && horse_training_properties_.h3_index
     WHERE marine_farms.h3_index IS NOT NULL OR linz_dvr_.h3_index IS NOT NULL
 );

--- a/classifications/nzlum/config.nzlum.yml
+++ b/classifications/nzlum/config.nzlum.yml
@@ -73,6 +73,7 @@ classifications:
       - topo50_golf_courses
       - topo50_chatham_golf_courses
       - topo50_sportsfields
+      - topo50_racetracks
       - topo50_cemetery
       - topo50_chatham_cemetery
       - topo50_landfill_polygons

--- a/classifications/nzlum/data_views/horse_training_properties.sql
+++ b/classifications/nzlum/data_views/horse_training_properties.sql
@@ -1,0 +1,20 @@
+-- H3 footprint of all unit_of_property parcels that contain a horse training track (topo50)
+CREATE TEMPORARY VIEW horse_training_properties_ AS
+SELECT DISTINCT uop_all_h3.h3_index,
+    'LINZ' AS source_data,
+    DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+    '[50,100]'::int4range AS source_scale
+FROM unit_of_property_h3 uop_all_h3
+JOIN unit_of_property uop_all USING (ogc_fid)
+WHERE :parent::h3index = uop_all_h3.h3_partition
+AND uop_all.unit_of_property_id IN (
+    SELECT DISTINCT uop.unit_of_property_id
+    FROM topo50_racetracks
+    JOIN topo50_racetracks_h3 ON topo50_racetracks.ogc_fid = topo50_racetracks_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_h3 ON topo50_racetracks_h3.h3_index && uop_h3.h3_index
+    JOIN unit_of_property uop ON uop_h3.ogc_fid = uop.ogc_fid
+    WHERE :parent::h3index = topo50_racetracks_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND topo50_racetracks.track_type = 'training'
+    AND topo50_racetracks.track_use  = 'horse'
+);

--- a/classifications/nzlum/nzlum.sql
+++ b/classifications/nzlum/nzlum.sql
@@ -33,6 +33,7 @@ CREATE TEMPORARY VIEW roi AS (
 \ir data_views/consents/forestry.sql
 \ir data_views/consents/pastoral_farms.sql
 \ir data_views/gwrc_plantation_forests.sql
+\ir data_views/horse_training_properties.sql
 
 -- attributes
 \ir attributes/water.sql

--- a/external-data/linz/topo50.yml
+++ b/external-data/linz/topo50.yml
@@ -31,6 +31,19 @@ external_data:
     layer: layer-50083
     geom_type: multipolygon
   
+  topo50_racetracks:
+    <<: *linz_topo50
+    description: LINZ Topo 1:50k racetracks
+    layer: layer-50315
+    geom_type: linestring
+    indices:
+      - columns: [track_type]
+        type: btree
+        name: idx_btree_track_type
+      - columns: [track_use]
+        type: btree
+        name: idx_btree_track_use
+
   topo50_cemetery:
     <<: *linz_topo50
     description: LINZ Topo 1:50k cemeteries


### PR DESCRIPTION
- Adds the LINZ topo50 horse tracks as input
- Joins these to property boundaries
- Uses this as evidence to justify classification
- Also now considers size as indicator of extensive (>20 ha) or intensive pastoralism in a "horse context".