### PR TITLE
relabels 3.6.0, adds some communications infras to 3.5.0

### DIFF
--- a/classifications/nzlum/classes/class_350.sql
+++ b/classifications/nzlum/classes/class_350.sql
@@ -20,6 +20,30 @@ CREATE TEMPORARY VIEW class_350 AS (
     5 AS lu_code_secondary,
     0 AS lu_code_tertiary,
     CASE
+        WHEN (
+            topo50_beacons.h3_index IS NOT NULL
+            OR topo50_masts.h3_index IS NOT NULL
+        )
+        THEN ROW(
+            ARRAY[]::TEXT[], -- lu_code_ancillary
+            1,
+            ARRAY[]::TEXT[],
+            ARRAY[]::TEXT[],
+            ARRAY[topo50_beacons.source_data, topo50_masts.source_data]::TEXT[],
+            range_merge(datemultirange(
+                VARIADIC ARRAY_REMOVE(ARRAY[
+                    topo50_beacons.source_date,
+                    topo50_masts.source_date
+                ], NULL)
+            ))::daterange,
+            range_merge(int4multirange(
+                VARIADIC ARRAY_REMOVE(ARRAY[
+                    topo50_beacons.source_scale,
+                    topo50_masts.source_scale
+                ], NULL)
+            ))::int4range,
+            NULL
+        )::nzlum_type
         WHEN topo50_hydro_and_reservoirs.h3_index IS NOT NULL
         THEN ROW(
             ARRAY[]::TEXT[], -- lu_code_ancillary
@@ -71,7 +95,7 @@ CREATE TEMPORARY VIEW class_350 AS (
             NULL
         )::nzlum_type
         WHEN (
-            linz_dvr_utility_.actual_property_use ~ '6[01234678]'
+            linz_dvr_utility_.actual_property_use ~ '6[0123467]'
             OR linz_dvr_utility_.actual_property_use = '06'
         )
         THEN ROW(
@@ -116,6 +140,36 @@ CREATE TEMPORARY VIEW class_350 AS (
     END AS nzlum_type
     FROM roi
     LEFT JOIN (
+        SELECT h3_index,
+            'LINZ' AS source_data,
+            DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+            '[50,100]'::int4range AS source_scale
+        FROM topo50_beacons_h3
+        WHERE :parent::h3index = h3_partition
+        UNION ALL
+        SELECT h3_index,
+            'LINZ' AS source_data,
+            DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+            '[50,100]'::int4range AS source_scale
+        FROM topo50_chatham_beacons_h3
+        WHERE :parent::h3index = h3_partition
+    ) AS topo50_beacons ON roi.h3_index && topo50_beacons.h3_index
+    LEFT JOIN (
+        SELECT h3_index,
+            'LINZ' AS source_data,
+            DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+            '[50,100]'::int4range AS source_scale
+        FROM topo50_masts_h3
+        WHERE :parent::h3index = h3_partition
+        UNION ALL
+        SELECT h3_index,
+            'LINZ' AS source_data,
+            DATERANGE(CURRENT_DATE, CURRENT_DATE, '[]') AS source_date,
+            '[50,100]'::int4range AS source_scale
+        FROM topo50_chatham_masts_h3
+        WHERE :parent::h3index = h3_partition
+    ) AS topo50_masts ON roi.h3_index && topo50_masts.h3_index
+    LEFT JOIN (
         SELECT
             h3_index,
             source_data,
@@ -144,7 +198,7 @@ CREATE TEMPORARY VIEW class_350 AS (
             END AS improvements_evidence
         FROM linz_dvr_
         WHERE
-            actual_property_use ~ '6[01234678]' -- 65 is sanitary (better as 3.8.X) and 69 is vacant (3.9.X)
+            actual_property_use ~ '6[0123467]' -- 65 is sanitary (better as 3.8.X) and 69 is vacant (3.9.X)
             OR actual_property_use = '06'
             OR category ~ '^U[CEGT]' -- UP (postboxes) and UR (rail network corridors) excluded
     ) AS linz_dvr_utility_ ON roi.h3_index && linz_dvr_utility_.h3_index
@@ -196,7 +250,9 @@ CREATE TEMPORARY VIEW class_350 AS (
             5 -- Transport infrastructure
         )
     ) AS lcdb_unbuilt ON roi.h3_index && lcdb_unbuilt.h3_index
-    WHERE linz_crosl_.h3_index IS NOT NULL
+    WHERE topo50_beacons.h3_index IS NOT NULL
+       OR topo50_masts.h3_index IS NOT NULL
+       OR linz_crosl_.h3_index IS NOT NULL
        OR linz_dvr_utility_.h3_index IS NOT NULL
        OR topo50_hydro_and_reservoirs.h3_index IS NOT NULL
        OR hail_electric.h3_index IS NOT NULL

--- a/classifications/nzlum/classes/class_360.sql
+++ b/classifications/nzlum/classes/class_360.sql
@@ -1,4 +1,4 @@
-CREATE TEMPORARY VIEW class_360 AS ( --Transport and communicaton
+CREATE TEMPORARY VIEW class_360 AS ( --Transportation
     SELECT roi.h3_index,
     3 AS lu_code_primary,
     6 AS lu_code_secondary,

--- a/classifications/nzlum/config.nzlum.yml
+++ b/classifications/nzlum/config.nzlum.yml
@@ -46,6 +46,10 @@ classifications:
       - topo50_chatham_airports
       - topo50_runways
       - topo50_chatham_runways
+      - topo50_beacons
+      - topo50_chatham_beacons
+      - topo50_masts
+      - topo50_chatham_masts
       - nz_facilities
       - topo50_sand
       - topo50_chatham_sand

--- a/classifications/nzlum/nzlum-preclassify.sql
+++ b/classifications/nzlum/nzlum-preclassify.sql
@@ -98,7 +98,7 @@ CREATE OR REPLACE FUNCTION nzsluc_v0_2_0_lu_description(lu_code_primary integer,
                         THEN 'Defence land'
                         ELSE 'Minimal use from relatively natural environments'
                     END
-                WHEN lu_code_secondary = 4 THEN 'Unused land and land in transition'
+                WHEN lu_code_secondary = 4 THEN 'Unused and transitioning land'
                 END
             
             WHEN lu_code_primary = 2
@@ -110,7 +110,7 @@ CREATE OR REPLACE FUNCTION nzsluc_v0_2_0_lu_description(lu_code_primary integer,
                 WHEN lu_code_secondary = 5 THEN 'Intensive horticulture'
                 WHEN lu_code_secondary = 6 THEN 'Intensive animal production'
                 WHEN lu_code_secondary = 7 THEN 'Water and wastewater'
-                WHEN lu_code_secondary = 8 THEN 'Land in transition'
+                WHEN lu_code_secondary = 8 THEN 'Vacant and transitioning land'
                 END
 
             WHEN lu_code_primary = 3
@@ -120,7 +120,7 @@ CREATE OR REPLACE FUNCTION nzsluc_v0_2_0_lu_description(lu_code_primary integer,
                 WHEN lu_code_secondary = 3 THEN 'Commercial'
                 WHEN lu_code_secondary = 4 THEN 'Manufacturing and industrial'
                 WHEN lu_code_secondary = 5 THEN 'Utilities'
-                WHEN lu_code_secondary = 6 THEN 'Transport and communication'
+                WHEN lu_code_secondary = 6 THEN 'Transportation'
                 WHEN lu_code_secondary = 7 THEN 'Mining'
                 WHEN lu_code_secondary = 8 THEN 'Waste treatment and disposal'
                 WHEN lu_code_secondary = 9 THEN 'Vacant and transitioning land'

--- a/external-data/linz/topo50.yml
+++ b/external-data/linz/topo50.yml
@@ -417,3 +417,37 @@ external_data:
       - columns: [species]
         type: btree
         name: idx_species
+
+  topo50_beacons:
+    <<: *linz_topo50
+    name: NZ Beacon Points (lighthouses)
+    description: LINZ Topo 1:50k Beacon Points — lighthouses only, buffered 10 m
+    layer: layer-50238
+    geom_type: multipolygon
+    where: "type = 'lighthouse' AND status NOT IN ('derelict', 'historic')"
+    replace_table: SELECT ogc_fid, ST_Buffer(geom::geography, 10, 'endcap=round join=round')::geometry AS geom
+
+  topo50_chatham_beacons:
+    <<: *linz_topo50
+    name: NZ Chatham Island Beacon Points (lighthouses)
+    description: LINZ Topo Chatham Island 1:50k Beacon Points — lighthouses only, buffered 10 m
+    layer: layer-50064
+    geom_type: multipolygon
+    where: "type = 'lighthouse' AND status NOT IN ('derelict', 'historic')"
+    replace_table: SELECT ogc_fid, ST_Buffer(geom::geography, 10, 'endcap=round join=round')::geometry AS geom
+
+  topo50_masts:
+    <<: *linz_topo50
+    name: NZ Mast Points
+    description: LINZ Topo 1:50k Mast Points (antenna masts ≥10 m or significant), buffered 10 m
+    layer: layer-50299
+    geom_type: multipolygon
+    replace_table: SELECT ogc_fid, ST_Buffer(geom::geography, 10, 'endcap=round join=round')::geometry AS geom
+
+  topo50_chatham_masts:
+    <<: *linz_topo50
+    name: NZ Chatham Island Mast Points
+    description: LINZ Topo Chatham Island 1:50k Mast Points (antenna masts ≥10 m or significant), buffered 10 m
+    layer: layer-50090
+    geom_type: multipolygon
+    replace_table: SELECT ogc_fid, ST_Buffer(geom::geography, 10, 'endcap=round join=round')::geometry AS geom


### PR DESCRIPTION
Closes #13

Adds some sources of point data (masts, lighthouses) to expand class 3.5.0 slightly.

NB:

`linz_dvr_utility_.actual_property_use ~ '6[0123467]'` --> class 68 doesn't exist, and was removed from this query.