### PR TITLE
selectively add regional consenting data

### DIFF
--- a/classifications/nzlum/classes/220/class_221.sql
+++ b/classifications/nzlum/classes/220/class_221.sql
@@ -44,20 +44,24 @@ CREATE TEMPORARY VIEW class_221 AS (
             THEN 1
             -- DVR dairy APU with at least one corroborating signal
             WHEN linz_dvr_.actual_property_use = '11'
-                AND (linz_dvr_.category ~ '^D' OR lum_dairy.h3_index IS NOT NULL)
+                AND (
+                    linz_dvr_.category ~ '^D'
+                    OR lum_dairy.h3_index IS NOT NULL
+                    OR pastoral_consents.h3_index IS NOT NULL
+                )
             THEN 2
             -- DVR dairy APU alone
             WHEN linz_dvr_.actual_property_use = '11'
             THEN 3
-            -- DVR category D (dairy) without APU confirmation
+            -- DVR category D alone
             WHEN linz_dvr_.category ~ '^D'
-            THEN 4
-            -- LUM dairy subid without DVR confirmation
+            THEN 6
+            -- LUM dairy subid alone
             WHEN lum_dairy.h3_index IS NOT NULL
-            THEN 4
+            THEN 6
             -- Pastoral consent specifying dairy commodity
             WHEN pastoral_consents.h3_index IS NOT NULL
-            THEN 4
+            THEN 6
             ELSE NULL
         END
         + CASE -- LCDB land cover contradicts pastoral/dairy use
@@ -92,11 +96,14 @@ CREATE TEMPORARY VIEW class_221 AS (
         + CASE -- Residential zoning contradicts commercial pastoral/dairy use
             WHEN linz_dvr_."zone" ~ '^9' THEN 3
             ELSE 0
+        END
+        + CASE -- Pastoral consent with dairy commodity corroborates across all cases
+            WHEN pastoral_consents.h3_index IS NOT NULL THEN -2
+            ELSE 0
         END),
         ARRAY['cattle dairy']::TEXT[], -- commod: dairy by definition
-        ARRAY_REMOVE(ARRAY[
-            GREATEST(irrigation_.manage, dairy_effluent_discharge.manage)
-        ], NULL)::TEXT[], -- manage
+        ARRAY_REMOVE(ARRAY[irrigation_.manage], NULL)::TEXT[]
+        || COALESCE(dairy_effluent_discharge.manage, ARRAY[]::TEXT[]), -- manage
         ARRAY[
             linz_dvr_.source_data,
             lcdb_.source_data,

--- a/classifications/nzlum/classes/220/class_222.sql
+++ b/classifications/nzlum/classes/220/class_222.sql
@@ -182,9 +182,8 @@ CREATE TEMPORARY VIEW class_222 AS (
                     ELSE ARRAY[]::TEXT[]
                 END
             ) || COALESCE(pasture_practices.commod, ARRAY[]::TEXT[]), -- commod
-            ARRAY_REMOVE(ARRAY[
-                GREATEST(irrigation_.manage, dairy_effluent_discharge.manage)
-            ], NULL)::TEXT[]
+            ARRAY_REMOVE(ARRAY[irrigation_.manage], NULL)::TEXT[]
+            || COALESCE(dairy_effluent_discharge.manage, ARRAY[]::TEXT[])
             || COALESCE(ARRAY[winter_forage_.manage]::TEXT[], ARRAY[]::TEXT[])
             || COALESCE(pasture_practices.manage, ARRAY[]::TEXT[]), -- manage
             ARRAY[

--- a/classifications/nzlum/classes/220/class_223.sql
+++ b/classifications/nzlum/classes/220/class_223.sql
@@ -180,9 +180,8 @@ CREATE TEMPORARY VIEW class_223 AS (
                     ELSE ARRAY[]::TEXT[]
                 END
             ) || COALESCE(pasture_practices.commod, ARRAY[]::TEXT[]), -- commod
-            ARRAY_REMOVE(ARRAY[
-                GREATEST(irrigation_.manage, dairy_effluent_discharge.manage)
-            ], NULL)::TEXT[]
+            ARRAY_REMOVE(ARRAY[irrigation_.manage], NULL)::TEXT[]
+            || COALESCE(dairy_effluent_discharge.manage, ARRAY[]::TEXT[])
             || COALESCE(ARRAY[winter_forage_.manage]::TEXT[], ARRAY[]::TEXT[])
             || COALESCE(pasture_practices.manage, ARRAY[]::TEXT[]), -- manage
             ARRAY[

--- a/classifications/nzlum/classes/320/class_321.sql
+++ b/classifications/nzlum/classes/320/class_321.sql
@@ -222,7 +222,7 @@ CREATE TEMPORARY VIEW class_321 AS (
     LEFT JOIN (
         SELECT h3_index, source_data, source_date, source_scale, hail_category_count
         FROM hail
-        WHERE hail_category_ids @> ARRAY['C2']
+        WHERE hail_category_ids && ARRAY['C2']
     ) AS hail_gun_clubs ON roi.h3_index && hail_gun_clubs.h3_index
     LEFT JOIN (
         -- PAN-NZ reserves in the same IUCN categories as class_117, but without requiring native cover.

--- a/classifications/nzlum/classes/320/class_323.sql
+++ b/classifications/nzlum/classes/320/class_323.sql
@@ -73,6 +73,17 @@ CREATE TEMPORARY VIEW class_323 AS (
             dvr_community.source_scale,
             NULL
         )::nzlum_type
+        WHEN hail_g1_.h3_index IS NOT NULL
+        THEN ROW(
+            ARRAY[]::TEXT[], -- lu_code_ancillary
+            8,
+            ARRAY[]::TEXT[], -- commod
+            ARRAY[]::TEXT[], -- manage
+            ARRAY[hail_g1_.source_data]::TEXT[],
+            hail_g1_.source_date,
+            hail_g1_.source_scale,
+            NULL
+        )::nzlum_type
         ELSE NULL
     END AS nzlum_type
     FROM roi
@@ -136,7 +147,13 @@ CREATE TEMPORARY VIEW class_323 AS (
         ) dvr_
         WHERE dvr_.community_improvements IS TRUE
     ) AS dvr_community ON roi.h3_index && dvr_community.h3_index
+    LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale
+        FROM hail
+        WHERE hail_category_ids && ARRAY['G1']
+    ) hail_g1_ ON roi.h3_index && hail_g1_.h3_index
     WHERE cemeteries.h3_index IS NOT NULL
        OR nz_facilities_.h3_index IS NOT NULL
        OR dvr_community.h3_index IS NOT NULL
+       OR hail_g1_.h3_index IS NOT NULL
 );

--- a/classifications/nzlum/classes/class_240.sql
+++ b/classifications/nzlum/classes/class_240.sql
@@ -278,6 +278,17 @@ CREATE TEMPORARY VIEW class_240 AS ( -- Perennial horticulture
                 linz_dvr_.source_scale,
                 NULL
             )::nzlum_type
+            WHEN hail_a10_.h3_index IS NOT NULL
+            THEN ROW(
+                ARRAY[]::TEXT[], -- lu_code_ancillary
+                9, -- weak standalone; outer SELECT applies -1 → 8 final
+                ARRAY[]::TEXT[], -- commod
+                ARRAY[]::TEXT[], -- manage
+                ARRAY[hail_a10_.source_data]::TEXT[],
+                hail_a10_.source_date,
+                hail_a10_.source_scale,
+                NULL
+            )::nzlum_type
             ELSE NULL
         END AS nzlum_type
         FROM roi
@@ -325,11 +336,17 @@ CREATE TEMPORARY VIEW class_240 AS ( -- Perennial horticulture
             -- Consider H*(A|B|C|D|E|F) too (quality)
         ) linz_dvr_ ON roi.h3_index && linz_dvr_.h3_index
         LEFT JOIN crop_perennial ON roi.h3_index && crop_perennial.h3_index
+        LEFT JOIN (
+            SELECT h3_index, source_data, source_date, source_scale
+            FROM hail
+            WHERE hail_category_ids && ARRAY['A10']
+        ) hail_a10_ ON roi.h3_index && hail_a10_.h3_index
         WHERE lum_.h3_index IS NOT NULL
            OR topo50_orchards_.h3_index IS NOT NULL
            OR lcdb_.h3_index IS NOT NULL
            OR linz_dvr_.h3_index IS NOT NULL
            OR crop_perennial.h3_index IS NOT NULL
+           OR hail_a10_.h3_index IS NOT NULL
     )
     SELECT
         base_classification.h3_index,
@@ -351,6 +368,11 @@ CREATE TEMPORARY VIEW class_240 AS ( -- Perennial horticulture
                     + CASE
                         WHEN crop_perennial.h3_index IS NOT NULL
                         THEN -6
+                        ELSE 0
+                    END
+                    + CASE
+                        WHEN hail_a10_.h3_index IS NOT NULL
+                        THEN -1
                         ELSE 0
                     END
                     + CASE -- Penalise confidence by irrigation age (older mapping = less certain)
@@ -393,6 +415,11 @@ CREATE TEMPORARY VIEW class_240 AS ( -- Perennial horticulture
         FROM irrigation_
         WHERE irrigation_type ~ '^Drip'
     ) irrigation_ ON base_classification.h3_index && irrigation_.h3_index
+    LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale
+        FROM hail
+        WHERE hail_category_ids && ARRAY['A10']
+    ) hail_a10_ ON base_classification.h3_index && hail_a10_.h3_index
 );
 
 -- Topo50. Middling confidence on its own. "Vegetation defined as pip or stone fruit eg apples, apricots, olives etc". No ancillary information available.

--- a/classifications/nzlum/classes/class_260.sql
+++ b/classifications/nzlum/classes/class_260.sql
@@ -15,6 +15,17 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
             marine_farms.source_scale,
             NULL
         )::nzlum_type
+        WHEN intensive_livestock_consents_.h3_index IS NOT NULL
+        THEN ROW(
+            ARRAY[]::TEXT[],
+            4,
+            intensive_livestock_consents_.commod,
+            ARRAY[]::TEXT[],
+            ARRAY[intensive_livestock_consents_.source_data]::TEXT[],
+            intensive_livestock_consents_.source_date,
+            intensive_livestock_consents_.source_scale,
+            NULL
+        )::nzlum_type
         WHEN (
             linz_dvr_.actual_property_use IN ('0', '00', '01', '1', '10', '16')
             AND (
@@ -91,6 +102,10 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
     FROM roi
     LEFT JOIN marine_farms ON roi.h3_index && marine_farms.h3_index
     LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale, commod
+        FROM intensive_livestock_consents
+    ) AS intensive_livestock_consents_ ON roi.h3_index && intensive_livestock_consents_.h3_index
+    LEFT JOIN (
         SELECT
             h3_index,
             source_data,
@@ -109,5 +124,7 @@ CREATE TEMPORARY VIEW class_260 AS ( -- Intensive animal production
         SELECT h3_index, source_data, source_date, source_scale
         FROM horse_training_properties_
     ) AS horse_training_properties_ ON roi.h3_index && horse_training_properties_.h3_index
-    WHERE marine_farms.h3_index IS NOT NULL OR linz_dvr_.h3_index IS NOT NULL
+    WHERE marine_farms.h3_index IS NOT NULL
+       OR intensive_livestock_consents_.h3_index IS NOT NULL
+       OR linz_dvr_.h3_index IS NOT NULL
 );

--- a/classifications/nzlum/classes/class_340.sql
+++ b/classifications/nzlum/classes/class_340.sql
@@ -87,7 +87,7 @@ CREATE TEMPORARY VIEW class_340 AS ( -- Manufacturing and industrial
             source_date,
             source_scale
         FROM hail
-        WHERE hail_category_ids @> ARRAY[
+        WHERE hail_category_ids && ARRAY[
             'A1', -- Agrichemicals
             'A2', -- Chemical manufacture
             'A3', -- Commercial analytical laboratory sites

--- a/classifications/nzlum/classes/class_360.sql
+++ b/classifications/nzlum/classes/class_360.sql
@@ -253,10 +253,11 @@ CREATE TEMPORARY VIEW class_360 AS ( --Transportation
             source_scale,
             hail_category_count
         FROM hail
-        WHERE hail_category_ids @> ARRAY[
+        WHERE hail_category_ids && ARRAY[
             'F1', -- Airports including fuel storage, workshops, washdown areas, or fire practice areas
             'F5', -- Port activities including dry docks or marine vessel maintenance facilities
-            'F6' -- Railway yards including goods-handling yards, workshops, refuelling facilities or maintenance areas
+            'F6', -- Railway yards including goods-handling yards, workshops, refuelling facilities or maintenance areas
+            'F8'  -- Vehicle or equipment depots, yards, and workshops
         ]
     ) AS hail_transport ON roi.h3_index && hail_transport.h3_index
     LEFT JOIN (

--- a/classifications/nzlum/classes/class_370.sql
+++ b/classifications/nzlum/classes/class_370.sql
@@ -119,6 +119,17 @@ CREATE TEMPORARY VIEW class_370 AS ( -- Mining
             linz_dvr_.source_scale,
             NULL
         )::nzlum_type
+        WHEN hail_mining_.h3_index IS NOT NULL
+        THEN ROW(
+            ARRAY[]::TEXT[], -- lu_code_ancillary
+            8,
+            ARRAY[]::TEXT[], -- commod
+            ARRAY[]::TEXT[], -- manage
+            ARRAY[hail_mining_.source_data]::TEXT[],
+            hail_mining_.source_date,
+            hail_mining_.source_scale,
+            NULL
+        )::nzlum_type
         ELSE NULL
     END AS nzlum_type
     -- commodity type? mines.substance = ironsand,coal, gold
@@ -221,12 +232,18 @@ CREATE TEMPORARY VIEW class_370 AS ( -- Mining
             )
             OR improvements_description ~ '/mQUARRY/M'
     ) AS linz_dvr_ ON roi.h3_index && linz_dvr_.h3_index
+    LEFT JOIN (
+        SELECT h3_index, source_data, source_date, source_scale
+        FROM hail
+        WHERE hail_category_ids && ARRAY['E7']
+    ) hail_mining_ ON roi.h3_index && hail_mining_.h3_index
     WHERE mines_.h3_index IS NOT NULL
        OR quarries_.h3_index IS NOT NULL
        OR evaporation_ponds_.h3_index IS NOT NULL
        OR settling_ponds_.h3_index IS NOT NULL
        OR dredge_tailings_.h3_index IS NOT NULL
        OR linz_dvr_.h3_index IS NOT NULL
+       OR hail_mining_.h3_index IS NOT NULL
 );
 
 -- Use DVR category for commodity

--- a/classifications/nzlum/classes/class_380.sql
+++ b/classifications/nzlum/classes/class_380.sql
@@ -122,6 +122,17 @@ CREATE TEMPORARY VIEW class_380 AS (
             linz_crosl_sanitary.source_scale,
             NULL
         )::nzlum_type
+        WHEN hail_waste_.h3_index IS NOT NULL
+        THEN ROW(
+            ARRAY[]::TEXT[], -- lu_code_ancillary
+            CASE WHEN hail_waste_.hail_category_ids && ARRAY['G3'] THEN 7 ELSE 8 END,
+            ARRAY[]::TEXT[], -- commod
+            ARRAY[]::TEXT[], -- manage
+            ARRAY[hail_waste_.source_data]::TEXT[],
+            hail_waste_.source_date,
+            hail_waste_.source_scale,
+            NULL
+        )::nzlum_type
         ELSE NULL
     END AS nzlum_type
     FROM roi
@@ -204,11 +215,17 @@ CREATE TEMPORARY VIEW class_380 AS (
         FROM lcdb_
         WHERE Class_2023 = 6 -- Surface Mine or Dump
     ) AS lcdb_mines_and_dumps ON roi.h3_index && lcdb_mines_and_dumps.h3_index
+    LEFT JOIN (
+        SELECT h3_index, hail_category_ids, source_data, source_date, source_scale
+        FROM hail
+        WHERE hail_category_ids && ARRAY['G3', 'G6']
+    ) hail_waste_ ON roi.h3_index && hail_waste_.h3_index
     WHERE topo50_landfill.h3_index IS NOT NULL
        OR topo50_pond.h3_index IS NOT NULL
        OR linz_dvr_sanitary.h3_index IS NOT NULL
        OR linz_crosl_sanitary.h3_index IS NOT NULL
        OR lcdb_mines_and_dumps.h3_index IS NOT NULL
+       OR hail_waste_.h3_index IS NOT NULL
 )
 
 -- LINZ landfill polyogons

--- a/classifications/nzlum/config.nzlum.yml
+++ b/classifications/nzlum/config.nzlum.yml
@@ -2,7 +2,7 @@ region_of_interest:
   id: urban_rural_2025
 
 h3:
-  resolution: 13
+  resolution: 11
 
 classifications:
   nzlum:

--- a/classifications/nzlum/config.nzlum.yml
+++ b/classifications/nzlum/config.nzlum.yml
@@ -101,12 +101,16 @@ classifications:
       - hbrc_hail_contaminated_for_lu_human
       - hbrc_hail_contaminated_for_lu_env
       - hbrc_hail_background_natural_state
+      - hbrc_hail_background_remediated
 
       - horizons_reg_act
+      - horizons_reg_act_point
 
       # - ecan_lakes
       - ecan_consented_activities_areas_active
+      - ecan_consented_activities_points_active
       - ecan_effluent_dairy_discharge_area
+      - ecan_effluent_dairy_discharge
       - ecan_braided_rivers
       - cera_red_zoned_land
 
@@ -114,11 +118,28 @@ classifications:
       - winter_crop_gdc
       - fosal_areas_tairawhiti
       
-      - es_slu
+      - es_hail
       - es_winter_forage_2017
 
       - gwrc_plantation_forests_western
       - gwrc_plantation_forests_eastern
+      - gwrc_resource_consents
+
+      - wrc_land_use_consents
+      # - wrc_discharge_permits # low ag signal
+
+      - orc_all_consents
+
+      - trc_land_use_consents
+      - trc_discharge_permits
+
+      - mdc_discharge_polygon
+      - mdc_discharge_point
+
+      - wcrc_consent_shapes
+      - wcrc_consent_points
+
+      - bop_all_consents
     table_schema:
       unit_id: BIGINT
       lu_code_primary: INTEGER

--- a/classifications/nzlum/data_views/consents/dairy_effluent_discharge.sql
+++ b/classifications/nzlum/data_views/consents/dairy_effluent_discharge.sql
@@ -12,11 +12,11 @@ CREATE TEMPORARY VIEW dairy_effluent_discharge AS (
         FROM ecan_effluent_dairy_discharge_area_h3
         INNER JOIN ecan_effluent_dairy_discharge_area USING (ogc_fid)
         WHERE :parent::h3index = h3_partition
-        ORDER BY 
+        ORDER BY
             h3_index,
-            fmDate DESC NULLS LAST, -- Most recently issued
-            Expires DESC NULLS LAST, -- Latest expiry
-            Area_HA DESC NULLS LAST, -- Largest
+            start_date DESC NULLS LAST,
+            end_date DESC NULLS LAST,
+            Area_HA DESC NULLS LAST,
             animal_count DESC NULLS LAST -- Most animals
     ),
     hbrc_effluent_discharge AS (
@@ -28,21 +28,257 @@ CREATE TEMPORARY VIEW dairy_effluent_discharge AS (
             source_data,
             source_scale,
             NULL::INTEGER AS animal_count,
-            'irrigation' AS manage
+            ARRAY['irrigation']::TEXT[] AS manage
         FROM hbrc_all_consent_polygons -- Spatially imprecise
         INNER JOIN hbrc_all_consent_polygons_h3 USING (ogc_fid)
         WHERE :parent::h3index = h3_partition
         AND ActPrimaryIndustry = 'Agriculture - Dairying'
         AND ActPrimaryPurpose = 'Wastewater - Untreated'
-        AND AuthorisationActivityType = 'Discharge Permit'
-        ORDER BY 
+        AND Authorisation_Activity_Type = 'Discharge Permit'
+        ORDER BY
             h3_index,
-            DecisionServedDate DESC NULLS LAST, -- Most recently issued
-            ExpiryDate DESC NULLS LAST, -- Latest expiry
+            Authorisation_Decision_Date DESC NULLS LAST, -- Most recently issued
+            Authorisation_Expiry_Date DESC NULLS LAST, -- Latest expiry
             Area_m2 DESC NULLS LAST, -- Largest
-            DocumentLink DESC NULLS LAST -- Prefer with more information
+            Document_Link DESC NULLS LAST -- Prefer with more information
+    ),
+    wrc_dairy AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM wrc_land_use_consents c
+        JOIN wrc_land_use_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.STATUS IN ('Current', 'Expired - S.124 Protection')
+        AND c.PRIMARY_INDUSTRY_PURPOSE = 'Agricultural farming - dairy'
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    wrc_discharge_dairy AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM wrc_discharge_permits c
+        JOIN wrc_discharge_permits_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.STATUS IN ('Current', 'Expired - S.124 Protection')
+        AND c.PRIMARY_INDUSTRY_PURPOSE = 'Agricultural farming - dairy'
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    gwrc_dairy AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM gwrc_resource_consents c
+        JOIN gwrc_resource_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.RCstatus = 'Granted'
+        AND c.Purpose_Desc ~* '\bdairy shed effluent\b'
+        AND c.RC_APT_DESC = 'DP - ANIMAL WASTE TO LAND'
+        AND c.source_date IS NOT NULL
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    orc_dairy AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM orc_all_consents c
+        JOIN orc_all_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.Consent_Status IN ('Current', 'Current - Variation in App')
+        AND c.activity_tsvector @@ phraseto_tsquery('english', 'dairy farm')
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    mdc_dairy AS (
+        SELECT DISTINCT ON (h3_index)
+            h3_index,
+            h3_partition,
+            source_date,
+            source_data,
+            source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM mdc_discharge_polygon
+        JOIN mdc_discharge_polygon_h3 USING (ogc_fid)
+        WHERE :parent::h3index = h3_partition
+        AND Status = 'Current'
+        AND ActivityType IN ('Dairy', 'Piggery & Dairy')
+        ORDER BY h3_index
+    ),
+    mdc_dairy_point AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM mdc_discharge_point c
+        JOIN mdc_discharge_point_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.Status = 'Current'
+        AND c.ActivityType IN ('Dairy', 'Piggery & Dairy')
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    wcrc_shapes_dairy AS (
+        SELECT DISTINCT ON (h3_index)
+            h3_index,
+            h3_partition,
+            source_date,
+            source_data,
+            source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM wcrc_consent_shapes
+        JOIN wcrc_consent_shapes_h3 USING (ogc_fid)
+        WHERE :parent::h3index = h3_partition
+        AND CurrentStatus = 'Current'
+        AND PrimaryIndustry = 'A0130 Dairy Cattle Farming'
+        ORDER BY h3_index, upper(source_date) DESC NULLS LAST
+    ),
+    wcrc_points_dairy AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM wcrc_consent_points c
+        JOIN wcrc_consent_points_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.CurrentStatus = 'Current'
+        AND c.PrimaryIndustry = 'A0130 Dairy Cattle Farming'
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    bop_dairy AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            NULL::INTEGER AS animal_count,
+            ARRAY[]::TEXT[] AS manage
+        FROM bop_all_consents c
+        JOIN bop_all_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.Status = 'Current'
+        AND c.Category = 'Dairy'
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    ),
+    ecan_effluent_discharge_point AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            c.animal_count,
+            c.manage
+        FROM ecan_effluent_dairy_discharge c
+        JOIN ecan_effluent_dairy_discharge_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST, c.animal_count DESC NULLS LAST
     )
     SELECT * FROM ecan_effluent_discharge
     UNION ALL
+    SELECT * FROM ecan_effluent_discharge_point
+    UNION ALL
     SELECT * FROM hbrc_effluent_discharge
+    UNION ALL
+    SELECT * FROM wrc_dairy
+    UNION ALL
+    SELECT * FROM wrc_discharge_dairy
+    UNION ALL
+    SELECT * FROM gwrc_dairy
+    UNION ALL
+    SELECT * FROM orc_dairy
+    UNION ALL
+    SELECT * FROM mdc_dairy
+    UNION ALL
+    SELECT * FROM mdc_dairy_point
+    UNION ALL
+    SELECT * FROM wcrc_shapes_dairy
+    UNION ALL
+    SELECT * FROM wcrc_points_dairy
+    UNION ALL
+    SELECT * FROM bop_dairy
 );

--- a/classifications/nzlum/data_views/consents/forestry.sql
+++ b/classifications/nzlum/data_views/consents/forestry.sql
@@ -18,12 +18,12 @@ WITH forestry_hbrc AS (
     INNER JOIN hbrc_all_consent_polygons_h3 USING (ogc_fid)
     WHERE :parent::h3index = h3_partition
     AND ActPrimaryIndustry = 'Forestry'
-    ORDER BY 
+    ORDER BY
         h3_index,
-        DecisionServedDate DESC NULLS LAST, -- Most recently issued
-        ExpiryDate DESC NULLS LAST, -- Latest expiry
+        Authorisation_Decision_Date DESC NULLS LAST, -- Most recently issued
+        Authorisation_Expiry_Date DESC NULLS LAST, -- Latest expiry
         Area_m2 DESC NULLS LAST, -- Largest
-        DocumentLink DESC NULLS LAST -- Prefer with more information
+        Document_Link DESC NULLS LAST -- Prefer with more information
 ),
 forestry_horizons AS (
     SELECT
@@ -33,54 +33,167 @@ forestry_horizons AS (
         source_data,
         source_scale,
         CASE
-            WHEN Ath_PurPrim ~ '\mAfforestation\M'
+            WHEN PRIMARY_PURPOSE ~ '\mAfforestation\M'
             THEN TRUE
             ELSE FALSE
         END AS afforestation_flag
-        -- Ath_IndPrim,
-        -- Ath_PurPrim
-    FROM horizons_reg_act 
+        -- PRIMARY_INDUSTRY,
+        -- PRIMARY_PURPOSE
+    FROM horizons_reg_act
     INNER JOIN horizons_reg_act_h3 USING (ogc_fid)
     WHERE :parent::h3index = h3_partition
-    AND Ath_IndPrim = 'Forestry'
+    AND STATUS = 'Current'
+    AND PRIMARY_INDUSTRY = 'Forestry'
     AND (
-        Ath_PurPrim IS NULL
+        PRIMARY_PURPOSE IS NULL
         OR (
-            Ath_PurPrim NOT LIKE 'Construction | Access Road %'
-            AND Ath_PurPrim NOT LIKE 'Manufacturing %'
-            AND Ath_PurPrim NOT LIKE 'Mining %'
+            PRIMARY_PURPOSE NOT LIKE 'Construction | Access Road %'
+            AND PRIMARY_PURPOSE NOT LIKE 'Manufacturing %'
+            AND PRIMARY_PURPOSE NOT LIKE 'Mining %'
         )
     )
-    ORDER BY 
+    ORDER BY
         h3_index,
-        Ath_Commence DESC NULLS LAST, -- Most recently issued
-        Ath_Expiry DESC NULLS LAST, -- Latest expiry
-        Shape__Area DESC NULLS LAST, -- Largest
-        CASE ath_status
-            WHEN 'Active'
-            THEN 1
-            WHEN 'Current'
-            THEN 1
-            WHEN 'Decision Served'
-            THEN 2
-            WHEN 'Lodged'
-            THEN 2
-            WHEN 'Not Yet Commenced'
-            THEN 2
-            WHEN 'On Hold'
-            THEN 3
-            WHEN 'Proposed'
-            THEN 4
-            WHEN 'Expired'
-            THEN 5
-            WHEN 'Surrendered'
-            THEN 5
-            ELSE NULL
-        END ASC NULLS LAST
+        COMMENCEMENT_DATE DESC NULLS LAST, -- Most recently issued
+        EXPIRY_DATE DESC NULLS LAST, -- Latest expiry
+        Shape_Area DESC NULLS LAST -- Largest
+),
+forestry_horizons_point AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        CASE
+            WHEN c.PRIMARY_PURPOSE ~ '\mAfforestation\M'
+            THEN TRUE
+            ELSE FALSE
+        END AS afforestation_flag
+    FROM horizons_reg_act_point c
+    JOIN horizons_reg_act_point_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.STATUS = 'Current'
+    AND c.PRIMARY_INDUSTRY = 'Forestry'
+    AND (
+        c.PRIMARY_PURPOSE IS NULL
+        OR (
+            c.PRIMARY_PURPOSE NOT LIKE 'Construction | Access Road %'
+            AND c.PRIMARY_PURPOSE NOT LIKE 'Manufacturing %'
+            AND c.PRIMARY_PURPOSE NOT LIKE 'Mining %'
+        )
+    )
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+),
+forestry_wrc AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        (
+            c.DESCRIPTIVE_TEXT ~* '\bafforestation\b'
+            OR c.ACTIVITY_SUBTYPE ~* '\bafforestation\b'
+        ) AS afforestation_flag
+    FROM wrc_land_use_consents c
+    JOIN wrc_land_use_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.STATUS IN ('Current', 'Expired - S.124 Protection')
+    AND c.PRIMARY_INDUSTRY_PURPOSE = 'Forestry'
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+),
+forestry_wrc_discharge AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        (
+            c.DESCRIPTIVE_TEXT ~* '\bafforestation\b'
+            OR c.ACTIVITY_SUBTYPE ~* '\bafforestation\b'
+        ) AS afforestation_flag
+    FROM wrc_discharge_permits c
+    JOIN wrc_discharge_permits_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.STATUS IN ('Current', 'Expired - S.124 Protection')
+    AND c.PRIMARY_INDUSTRY_PURPOSE = 'Forestry'
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+),
+trc_afforestation AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        TRUE AS afforestation_flag
+    FROM trc_land_use_consents c
+    JOIN trc_land_use_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.Status = 'Current'
+    AND c.Activity_Subtype = 'Forestry – Afforestation'
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+),
+wcrc_points_forestry AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        FALSE AS afforestation_flag
+    FROM wcrc_consent_points c
+    JOIN wcrc_consent_points_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.CurrentStatus = 'Current'
+    AND c.PrimaryIndustry = 'A0301 Forestry'
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
 )
 SELECT * FROM forestry_hbrc
 UNION ALL
-SELECT * FROM forestry_horizons;
+SELECT * FROM forestry_horizons
+UNION ALL
+SELECT * FROM forestry_horizons_point
+UNION ALL
+SELECT * FROM forestry_wrc
+UNION ALL
+SELECT * FROM forestry_wrc_discharge
+UNION ALL
+SELECT * FROM trc_afforestation
+UNION ALL
+SELECT * FROM wcrc_points_forestry;
 
 -- TODO ActPrimaryPurpose = 'Forestry - Afforestation' OR 'Mechanical Land Preparation' (transitionary class?)
 -- TODO harvesting consent = commodity = {sawlogs,pulpwood}?

--- a/classifications/nzlum/data_views/consents/intensive_livestock.sql
+++ b/classifications/nzlum/data_views/consents/intensive_livestock.sql
@@ -1,0 +1,33 @@
+CREATE TEMPORARY VIEW intensive_livestock_consents AS (
+    WITH wrc_discharge_intensive AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            CASE
+                WHEN c.PRIMARY_INDUSTRY_PURPOSE = 'Agricultural farming - pigs'
+                THEN ARRAY['pigs']::TEXT[]
+                WHEN c.PRIMARY_INDUSTRY_PURPOSE = 'Agricultural farming - poultry (broiler)'
+                THEN ARRAY['chickens']::TEXT[]
+                ELSE ARRAY[]::TEXT[]
+            END AS commod
+        FROM wrc_discharge_permits c
+        JOIN wrc_discharge_permits_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.STATUS IN ('Current', 'Expired - S.124 Protection')
+        AND c.PRIMARY_INDUSTRY_PURPOSE IN (
+            'Agricultural farming - pigs',
+            'Agricultural farming - poultry (broiler)'
+        )
+        ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+    )
+    SELECT * FROM wrc_discharge_intensive
+);

--- a/classifications/nzlum/data_views/consents/pastoral_farms.sql
+++ b/classifications/nzlum/data_views/consents/pastoral_farms.sql
@@ -8,26 +8,46 @@ WITH hbrc_pastoral AS (
         source_data,
         source_scale,
         CASE
-            WHEN
-            ActPrimaryPurpose = 'Feedpad / Feedlot'
+            WHEN ActPrimaryPurpose = 'Feedpad / Feedlot'
             THEN TRUE
             ELSE FALSE
         END AS intensive,
         (CASE
-            WHEN ActPrimaryIndustry = 'Agriculture - Deer' OR ActSecondaryIndustry = 'Agriculture - Deer'
-            THEN ARRAY['deer']::TEXT[]
-            ELSE ARRAY[]::TEXT[]
-        END || CASE
-            WHEN ActPrimaryIndustry = 'Agriculture - Dairying' OR ActSecondaryIndustry = 'Agriculture - Dairying'
+            WHEN ActPrimaryIndustry = 'Agriculture - Dairying'
+              OR ActSecondaryIndustry = 'Agriculture - Dairying'
+              OR AuthPrimaryIndustry = 'Agriculture - Dairying'
+              OR AuthSecondaryIndustry = 'Agriculture - Dairying'
             THEN ARRAY['cattle dairy']::TEXT[]
             ELSE ARRAY[]::TEXT[]
         END || CASE
-            -- NB "Sheep /Beef" is not a typo
-            WHEN ActPrimaryIndustry = 'Agriculture - Sheep /Beef' OR ActSecondaryIndustry = 'Agriculture - Sheep /Beef'
+            WHEN ActPrimaryIndustry = 'Agriculture - Deer'
+              OR ActSecondaryIndustry = 'Agriculture - Deer'
+              OR AuthPrimaryIndustry = 'Agriculture - Deer'
+              OR AuthSecondaryIndustry = 'Agriculture - Deer'
+            THEN ARRAY['deer']::TEXT[]
+            ELSE ARRAY[]::TEXT[]
+        END || CASE
+            -- NB space before "/" is real in some records; regex handles both variants
+            WHEN ActPrimaryIndustry ~ 'Agriculture - Sheep ?.?/Beef'
+              OR ActSecondaryIndustry ~ 'Agriculture - Sheep ?.?/Beef'
+              OR AuthPrimaryIndustry ~ 'Agriculture - Sheep ?.?/Beef'
+              OR AuthSecondaryIndustry ~ 'Agriculture - Sheep ?.?/Beef'
             THEN ARRAY['sheep', 'cattle meat']::TEXT[]
             ELSE ARRAY[]::TEXT[]
         END || CASE
-            WHEN ActPrimaryIndustry = 'Agriculture - Beef' OR ActSecondaryIndustry = 'Agriculture - Beef'
+            WHEN (ActPrimaryIndustry = 'Agriculture - Sheep'
+               OR ActSecondaryIndustry = 'Agriculture - Sheep'
+               OR AuthPrimaryIndustry = 'Agriculture - Sheep'
+               OR AuthSecondaryIndustry = 'Agriculture - Sheep')
+            AND NOT (ActPrimaryIndustry ~ 'Agriculture - Sheep ?.?/Beef'
+                  OR AuthPrimaryIndustry ~ 'Agriculture - Sheep ?.?/Beef')
+            THEN ARRAY['sheep']::TEXT[]
+            ELSE ARRAY[]::TEXT[]
+        END || CASE
+            WHEN ActPrimaryIndustry = 'Agriculture - Beef'
+              OR ActSecondaryIndustry = 'Agriculture - Beef'
+              OR AuthPrimaryIndustry = 'Agriculture - Beef'
+              OR AuthSecondaryIndustry = 'Agriculture - Beef'
             THEN ARRAY['cattle meat']::TEXT[]
             ELSE ARRAY[]::TEXT[]
         END) AS commod,
@@ -39,16 +59,19 @@ WITH hbrc_pastoral AS (
     FROM hbrc_all_consent_polygons -- Spatially imprecise
     INNER JOIN hbrc_all_consent_polygons_h3 USING (ogc_fid)
     WHERE :parent::h3index = h3_partition
-    AND ActPrimaryIndustry ~ '^Agriculture - (Sheep /Beef|Dairying|Beef|Pastoral Farming)'
+    AND (
+        ActPrimaryIndustry ~ '^Agriculture - (Sheep|Dairying|Beef|Pastoral Farming)'
+        OR AuthPrimaryIndustry ~ '^Agriculture - (Sheep|Dairying|Beef|Pastoral Farming)'
+    )
     AND ActPrimaryPurpose !~ '^Forestry'
     -- TODO ActPrimaryPurpose = 'Forestry - Afforestation' OR 'Mechanical Land Preparation' (transitionary class?)
     -- TODO harvesting consent = commodity = {sawlogs,pulpwood}?
-    ORDER BY 
+    ORDER BY
         h3_index,
-        DecisionServedDate DESC NULLS LAST, -- Most recently issued
-        ExpiryDate DESC NULLS LAST, -- Latest expiry
+        Authorisation_Decision_Date DESC NULLS LAST, -- Most recently issued
+        Authorisation_Expiry_Date DESC NULLS LAST, -- Latest expiry
         Area_m2 DESC NULLS LAST, -- Largest
-        DocumentLink DESC NULLS LAST -- Prefer with more information
+        Document_Link DESC NULLS LAST -- Prefer with more information
 ), horizons_pastoral AS (
     SELECT DISTINCT ON (h3_index)
         h3_index,
@@ -56,42 +79,43 @@ WITH hbrc_pastoral AS (
         source_data,
         source_scale,
         CASE
-            WHEN ATH_PURPRIM ~ '^Agriculture, Intensive Farming' OR ATH_PURSEC ~ '^Agriculture, Intensive Farming'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture, Intensive Farming' OR SECONDARY_PURPOSE ~ '^Agriculture, Intensive Farming'
                 THEN TRUE
             ELSE FALSE
         END AS intensive,
         (CASE
-            WHEN ATH_PURPRIM ~ '^Agriculture.*\mBeef\M' OR ATH_PURSEC ~ '^Agriculture.*\mBeef\M'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture.*\mBeef\M' OR SECONDARY_PURPOSE ~ '^Agriculture.*\mBeef\M'
             THEN ARRAY['cattle meat']
             ELSE ARRAY[]::TEXT[]
         END || CASE
-            WHEN ATH_PURPRIM ~ '^Agriculture.*\mSheep\M' OR ATH_PURSEC ~ '^Agriculture.*\mSheep\M'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture.*\mSheep\M' OR SECONDARY_PURPOSE ~ '^Agriculture.*\mSheep\M'
             THEN ARRAY['sheep']
             ELSE ARRAY[]::TEXT[]
         END || CASE
-            WHEN ATH_PURPRIM ~ '^Agriculture.*\mDairy Goat\M' OR ATH_PURSEC ~ '^Agriculture.*\mDairy Goat\M'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture.*\mDairy Goat\M' OR SECONDARY_PURPOSE ~ '^Agriculture.*\mDairy Goat\M'
             THEN ARRAY['goats dairy']
-            WHEN ATH_PURPRIM ~ '^Agriculture.*\mGoat\M' OR ATH_PURSEC ~ '^Agriculture.*\mGoat\M'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture.*\mGoat\M' OR SECONDARY_PURPOSE ~ '^Agriculture.*\mGoat\M'
             THEN ARRAY['goats']
             ELSE ARRAY[]::TEXT[]
         END || CASE
-            WHEN ATH_PURPRIM ~ '^Agriculture.*\mDairy Cattle\M' OR ATH_PURSEC ~ '^Agriculture.*\mDairy Cattle\M'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture.*\mDairy Cattle\M' OR SECONDARY_PURPOSE ~ '^Agriculture.*\mDairy Cattle\M'
             THEN ARRAY['cattle dairy']
-            WHEN ATH_PURPRIM ~ '^Agriculture.*\mIntensive Farming, Dairy\M' OR ATH_PURSEC ~ '^Agriculture.*\mIntensive Farming, Dairy\M'
+            WHEN PRIMARY_PURPOSE ~ '^Agriculture.*\mIntensive Farming, Dairy\M' OR SECONDARY_PURPOSE ~ '^Agriculture.*\mIntensive Farming, Dairy\M'
             THEN ARRAY['cattle dairy']
             ELSE ARRAY[]::TEXT[]
         END
         ) AS commod,
         CASE
-            WHEN ATH_TYPE = 'Water Permit' AND ATH_INDPRIM = 'Agriculture'
-            THEN ARRAY['irrigation']
-            ELSE NULL
+            WHEN ACTIVITY_TYPE = 'Water Permit' AND PRIMARY_INDUSTRY = 'Agriculture'
+            THEN ARRAY['irrigation']::TEXT[]
+            ELSE NULL::TEXT[]
         END AS manage
     FROM horizons_reg_act
     JOIN horizons_reg_act_h3 USING (ogc_fid)
     WHERE :parent::h3index = h3_partition
+    AND STATUS = 'Current'
     AND (
-        ATH_PURPRIM IN (
+        PRIMARY_PURPOSE IN (
             'Agriculture | Beef Cattle Farming',
             'Agriculture | Dairy Cattle Farming',
             'Agriculture | Dairy Goat Farming',
@@ -99,7 +123,7 @@ WITH hbrc_pastoral AS (
             'Agriculture | Other Livestock Farming',
             'Agriculture | Pasture Cultivation (Irrigation, Animal Effluent, Fertiliser or Biosolids)',
             'Agriculture | Sheep & Beef Cattle Farming'
-        ) OR ATH_PURSEC IN (
+        ) OR SECONDARY_PURPOSE IN (
             'Agriculture | Beef Cattle Farming',
             'Agriculture | Dairy Cattle Farming',
             'Agriculture | Dairy Goat Farming',
@@ -109,11 +133,227 @@ WITH hbrc_pastoral AS (
             'Agriculture | Sheep & Beef Cattle Farming'
         )
     )
-    ORDER BY 
+    ORDER BY
         h3_index,
-        ATH_EXPIRY DESC NULLS LAST, -- Most recently issued
-        ATH_GRANTED DESC NULLS LAST -- Most recentlty granted
+        EXPIRY_DATE DESC NULLS LAST,
+        GRANTED_DATE DESC NULLS LAST
+), horizons_pastoral_point AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        CASE
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture, Intensive Farming' OR c.SECONDARY_PURPOSE ~ '^Agriculture, Intensive Farming'
+                THEN TRUE
+            ELSE FALSE
+        END AS intensive,
+        (CASE
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture.*\mBeef\M' OR c.SECONDARY_PURPOSE ~ '^Agriculture.*\mBeef\M'
+            THEN ARRAY['cattle meat']
+            ELSE ARRAY[]::TEXT[]
+        END || CASE
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture.*\mSheep\M' OR c.SECONDARY_PURPOSE ~ '^Agriculture.*\mSheep\M'
+            THEN ARRAY['sheep']
+            ELSE ARRAY[]::TEXT[]
+        END || CASE
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture.*\mDairy Goat\M' OR c.SECONDARY_PURPOSE ~ '^Agriculture.*\mDairy Goat\M'
+            THEN ARRAY['goats dairy']
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture.*\mGoat\M' OR c.SECONDARY_PURPOSE ~ '^Agriculture.*\mGoat\M'
+            THEN ARRAY['goats']
+            ELSE ARRAY[]::TEXT[]
+        END || CASE
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture.*\mDairy Cattle\M' OR c.SECONDARY_PURPOSE ~ '^Agriculture.*\mDairy Cattle\M'
+            THEN ARRAY['cattle dairy']
+            WHEN c.PRIMARY_PURPOSE ~ '^Agriculture.*\mIntensive Farming, Dairy\M' OR c.SECONDARY_PURPOSE ~ '^Agriculture.*\mIntensive Farming, Dairy\M'
+            THEN ARRAY['cattle dairy']
+            ELSE ARRAY[]::TEXT[]
+        END) AS commod,
+        CASE
+            WHEN c.ACTIVITY_TYPE = 'Water Permit' AND c.PRIMARY_INDUSTRY = 'Agriculture'
+            THEN ARRAY['irrigation']::TEXT[]
+            ELSE NULL::TEXT[]
+        END AS manage
+    FROM horizons_reg_act_point c
+    JOIN horizons_reg_act_point_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.STATUS = 'Current'
+    AND (
+        c.PRIMARY_PURPOSE IN (
+            'Agriculture | Beef Cattle Farming',
+            'Agriculture | Dairy Cattle Farming',
+            'Agriculture | Dairy Goat Farming',
+            'Agriculture | Grains, Forage & Other Crop Cultivation',
+            'Agriculture | Other Livestock Farming',
+            'Agriculture | Pasture Cultivation (Irrigation, Animal Effluent, Fertiliser or Biosolids)',
+            'Agriculture | Sheep & Beef Cattle Farming'
+        ) OR c.SECONDARY_PURPOSE IN (
+            'Agriculture | Beef Cattle Farming',
+            'Agriculture | Dairy Cattle Farming',
+            'Agriculture | Dairy Goat Farming',
+            'Agriculture | Grains, Forage & Other Crop Cultivation',
+            'Agriculture | Other Livestock Farming',
+            'Agriculture | Pasture Cultivation (Irrigation, Animal Effluent, Fertiliser or Biosolids)',
+            'Agriculture | Sheep & Beef Cattle Farming'
+        )
+    )
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+), wrc_pastoral AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        FALSE AS intensive,
+        CASE
+            WHEN c.PRIMARY_INDUSTRY_PURPOSE = 'Agricultural farming - dairy'
+            THEN ARRAY['cattle dairy']::TEXT[]
+            ELSE ARRAY[]::TEXT[]
+        END AS commod,
+        NULL::TEXT[] AS manage
+    FROM wrc_land_use_consents c
+    JOIN wrc_land_use_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.STATUS IN ('Current', 'Expired - S.124 Protection')
+    AND c.PRIMARY_INDUSTRY_PURPOSE IN (
+        'Agricultural farming - dairy',
+        'Agricultural farming - general',
+        'Agricultural farming - drystock'
+    )
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+), orc_winter_grazing AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        TRUE AS intensive,
+        ARRAY[]::TEXT[] AS commod,
+        ARRAY['winter grazing']::TEXT[] AS manage
+    FROM orc_all_consents c
+    JOIN orc_all_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.Consent_Status IN ('Current', 'Current - Variation in App')
+    AND c.activity_tsvector @@ phraseto_tsquery('english', 'intensive winter grazing')
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+), orc_dairy_pastoral AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        FALSE AS intensive,
+        ARRAY['cattle dairy']::TEXT[] AS commod,
+        NULL::TEXT[] AS manage
+    FROM orc_all_consents c
+    JOIN orc_all_consents_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.Consent_Status IN ('Current', 'Current - Variation in App')
+    AND c.activity_tsvector @@ phraseto_tsquery('english', 'dairy farm')
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+), trc_pastoral AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        FALSE AS intensive,
+        ARRAY[]::TEXT[] AS commod,
+        NULL::TEXT[] AS manage
+    FROM trc_discharge_permits c
+    JOIN trc_discharge_permits_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.Status = 'Current'
+    AND c.PrimaryIndustryPurpose = 'Agriculture'
+    AND c.Activity_Subtype IN ('Land - Animal Waste', 'Land/Water - Animal Waste', 'Water - Animal Waste')
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
+), wcrc_shapes_pastoral AS (
+    SELECT DISTINCT ON (h3_index)
+        h3_index,
+        source_date,
+        source_data,
+        source_scale,
+        FALSE AS intensive,
+        ARRAY['cattle dairy']::TEXT[] AS commod,
+        NULL::TEXT[] AS manage
+    FROM wcrc_consent_shapes
+    JOIN wcrc_consent_shapes_h3 USING (ogc_fid)
+    WHERE :parent::h3index = h3_partition
+    AND CurrentStatus = 'Current'
+    AND PrimaryIndustry = 'A0130 Dairy Cattle Farming'
+    ORDER BY h3_index, upper(source_date) DESC NULLS LAST
+), wcrc_points_pastoral AS (
+    SELECT DISTINCT ON (uop_h3.h3_index)
+        uop_h3.h3_index,
+        c.source_date,
+        c.source_data,
+        c.source_scale,
+        FALSE AS intensive,
+        ARRAY['cattle dairy']::TEXT[] AS commod,
+        NULL::TEXT[] AS manage
+    FROM wcrc_consent_points c
+    JOIN wcrc_consent_points_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+    JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+    JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+        AND ST_Within(c.geom, uop_inner.geom)
+    JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+    JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+    WHERE :parent::h3index = c_h3.h3_partition
+    AND   :parent::h3index = uop_inner_h3.h3_partition
+    AND   :parent::h3index = uop_h3.h3_partition
+    AND c.CurrentStatus = 'Current'
+    AND c.PrimaryIndustry = 'A0130 Dairy Cattle Farming'
+    ORDER BY uop_h3.h3_index, upper(c.source_date) DESC NULLS LAST
 )
 SELECT * FROM hbrc_pastoral
 UNION ALL
-SELECT * FROM horizons_pastoral;
+SELECT * FROM horizons_pastoral
+UNION ALL
+SELECT * FROM horizons_pastoral_point
+UNION ALL
+SELECT * FROM wrc_pastoral
+UNION ALL
+SELECT * FROM orc_winter_grazing
+UNION ALL
+SELECT * FROM orc_dairy_pastoral
+UNION ALL
+SELECT * FROM trc_pastoral
+UNION ALL
+SELECT * FROM wcrc_shapes_pastoral
+UNION ALL
+SELECT * FROM wcrc_points_pastoral;

--- a/classifications/nzlum/data_views/hail.sql
+++ b/classifications/nzlum/data_views/hail.sql
@@ -1,18 +1,5 @@
 CREATE TEMPORARY VIEW hail AS (
-    WITH _env_southland_hail AS (
-        SELECT
-            h3_index,
-            hail_category_count,
-            hail_category_ids,
-            -- geom_area_ha,
-            source_date,
-            source_data,
-            source_scale
-        FROM es_slu
-        INNER JOIN es_slu_h3 USING (ogc_fid)
-        WHERE :parent::h3index = h3_partition
-    ),
-    _hbrc_hail AS (
+    WITH _hbrc_hail AS (
         SELECT h3_index, hail_category_count, hail_category_ids, source_date, source_data, source_scale
         FROM hbrc_hail_suitable_remediated
         INNER JOIN hbrc_hail_suitable_remediated_h3 USING (ogc_fid)
@@ -59,8 +46,21 @@ CREATE TEMPORARY VIEW hail AS (
         FROM hbrc_hail_background_natural_state
         INNER JOIN hbrc_hail_background_natural_state_h3 USING (ogc_fid)
         WHERE :parent::h3index = h3_partition
+
+        UNION ALL
+
+        SELECT h3_index, hail_category_count, hail_category_ids, source_date, source_data, source_scale
+        FROM hbrc_hail_background_remediated
+        INNER JOIN hbrc_hail_background_remediated_h3 USING (ogc_fid)
+        WHERE :parent::h3index = h3_partition
+    ),
+    _es_hail AS (
+        SELECT h3_index, hail_category_count, hail_category_ids, source_date, source_data, source_scale
+        FROM es_hail
+        INNER JOIN es_hail_h3 USING (ogc_fid)
+        WHERE :parent::h3index = h3_partition
     )
-    SELECT * FROM _env_southland_hail
-    UNION ALL
     SELECT * FROM _hbrc_hail
+    UNION ALL
+    SELECT * FROM _es_hail
 );

--- a/classifications/nzlum/data_views/irrigation.sql
+++ b/classifications/nzlum/data_views/irrigation.sql
@@ -83,12 +83,38 @@ CREATE TEMPORARY VIEW irrigation_ AS (
             toDate DESC NULLS LAST, -- Latest expiry
             area_ha, -- Prefer larger
             link -- Prefer with more information
+    ),
+    ecan_irrigation_consents_point AS (
+        SELECT DISTINCT ON (uop_h3.h3_index)
+            uop_h3.h3_index,
+            uop_h3.h3_partition,
+            NULL::tsvector AS ts_notes,
+            'Current' AS "status",
+            'Low' AS confidence,
+            NULL AS irrigation_type,
+            c.source_date,
+            c.source_data,
+            c.source_scale,
+            'irrigation'::TEXT AS manage,
+            NULL::int AS irrigation_age
+        FROM ecan_consented_activities_points_active c
+        JOIN ecan_consented_activities_points_active_h3 c_h3 ON c.ogc_fid = c_h3.ogc_fid
+        JOIN unit_of_property_h3 uop_inner_h3 ON c_h3.h3_index && uop_inner_h3.h3_index
+        JOIN unit_of_property uop_inner ON uop_inner_h3.ogc_fid = uop_inner.ogc_fid
+            AND ST_Within(c.geom, uop_inner.geom)
+        JOIN unit_of_property uop_all ON uop_inner.unit_of_property_id = uop_all.unit_of_property_id
+        JOIN unit_of_property_h3 uop_h3 ON uop_all.ogc_fid = uop_h3.ogc_fid
+        WHERE :parent::h3index = c_h3.h3_partition
+        AND   :parent::h3index = uop_inner_h3.h3_partition
+        AND   :parent::h3index = uop_h3.h3_partition
+        AND c.current = TRUE
+        AND c.FeatureType = 'Irrigation Area'
+        ORDER BY uop_h3.h3_index, start_date DESC NULLS LAST, end_date DESC NULLS LAST
     )
     SELECT *
     FROM irrigation_mapping
 
-    -- union with an anti-join
-    -- i.e. prefer irrigation_mapping, but supplement it with information from irrigation_consents
+    -- union with anti-joins: prefer irrigation_mapping > area consents > point consents
     UNION ALL
 
     SELECT *
@@ -97,5 +123,20 @@ CREATE TEMPORARY VIEW irrigation_ AS (
         SELECT 1
         FROM irrigation_mapping
         WHERE irrigation_mapping.h3_index && irrigation_consents.h3_index
+    )
+
+    UNION ALL
+
+    SELECT *
+    FROM ecan_irrigation_consents_point
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM irrigation_mapping
+        WHERE irrigation_mapping.h3_index && ecan_irrigation_consents_point.h3_index
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM irrigation_consents
+        WHERE irrigation_consents.h3_index && ecan_irrigation_consents_point.h3_index
     )
 );

--- a/classifications/nzlum/nzlum.sql
+++ b/classifications/nzlum/nzlum.sql
@@ -32,6 +32,7 @@ CREATE TEMPORARY VIEW roi AS (
 \ir data_views/consents/dairy_effluent_discharge.sql
 \ir data_views/consents/forestry.sql
 \ir data_views/consents/pastoral_farms.sql
+\ir data_views/consents/intensive_livestock.sql
 \ir data_views/gwrc_plantation_forests.sql
 \ir data_views/horse_training_properties.sql
 \ir data_views/property_density.sql

--- a/external-data/landcare/landcare.yml
+++ b/external-data/landcare/landcare.yml
@@ -148,7 +148,7 @@ external_data:
         set_query: daterange('2022-06-01'::DATE, '2022-08-31'::DATE::DATE, '[]')
       - column: source_data
         datatype: text
-        set_query: "'MWLR'::TEXT"
+        set_query: "'BSI'::TEXT"
       - column: source_scale
         datatype: int4range
         set_query: "'[10,60]'::int4range"
@@ -188,7 +188,7 @@ external_data:
         set_query: daterange('2023-06-01'::DATE, '2023-08-31'::DATE::DATE, '[]')
       - column: source_data
         datatype: text
-        set_query: "'MWLR'::TEXT"
+        set_query: "'BSI'::TEXT"
       - column: source_scale
         datatype: int4range
         set_query: "'[10,60]'::int4range"

--- a/external-data/linz/nz_properties.yml
+++ b/external-data/linz/nz_properties.yml
@@ -25,18 +25,29 @@ _dvr_public: &dvr_public
   <<: *linz_nz_properties
   layer: layer-114085
 
-_dvr_local: &dvr_local
+_dvr_local_202406:
   <<: *linz_nz_properties_local_restricted
   layer: NZ_Properties__National_District_Valuation_Roll__restricted_access_
   file:
-    # local: /home/lawr/dvr-restricted/nz-properties-national-district-valuation-roll-restricted-ac.gdb # June 2024
+    local: /home/lawr/dvr-restricted/nz-properties-national-district-valuation-roll-restricted-ac.gdb
+
+_dvr_local_202505:
+  <<: *linz_nz_properties_local_restricted
+  layer: NZ_Properties__National_District_Valuation_Roll__restricted_access_
+  file:
     local: /home/lawr/dvr-restricted/nz-properties-national-district-valuation-roll-restricted-ac-20250508.gdb
+
+_dvr_local_202605: &dvr_local
+  <<: *linz_nz_properties_local_restricted
+  layer: nz_properties_national_district_valuation_roll_restricted_ac
+  file:
+    local: /home/lawr/dvr-restricted/nz-properties-national-district-valuation-roll-restricted-ac.gpkg
 
 external_data:
 
   unit_of_property:
-    # <<: *uop_public
-    <<: *uop_local
+    <<: *uop_public
+    # <<: *uop_local
     description: |-
       This pilot dataset provides a representation of the boundaries of all known properties in New Zealand.
     geom_type: multipolygon

--- a/external-data/regional-govt/bop.yml
+++ b/external-data/regional-govt/bop.yml
@@ -1,0 +1,42 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+external_data:
+  bop_all_consents:
+    license: https://creativecommons.org/licenses/by/4.0/
+    attribution: Bay of Plenty Regional Council
+    external_data_type: kart
+    geom_type: point
+    description: BOP RC Consents and Compliance — Current Consents (LRIS 123392)
+      # Active: Status = 'Current'. Dairy: Category = 'Dairy'.
+      # Factory_Supply_Number is populated only for dairy consents.
+      # Purpose is free-form text; purpose_tsvector enables GIN phrase search.
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/bop-rc-consents-and-compliance-current-consents
+    layer: bop-rc-consents-and-compliance-current-consents
+    indices:
+      - columns: [Category]
+        type: btree
+        name: idx_btree_category
+      - columns: [Status]
+        type: btree
+        name: idx_btree_status
+      - columns: [purpose_tsvector]
+        type: gin
+        name: idx_gin_purpose_tsvector
+    derived_columns:
+      - column: purpose_tsvector
+        datatype: tsvector
+        set_query: "to_tsvector('english', COALESCE(\"Purpose\", ''))"
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"Granted_Date\"::DATE, \"ExpiryDate\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'BOP consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/external-data/regional-govt/ecan.yml
+++ b/external-data/regional-govt/ecan.yml
@@ -1,61 +1,150 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
 __ecan__: &ecan
   external_data_type: arcgis_rest
   license: https://creativecommons.org/licenses/by/4.0/
   attribution: Sourced from Canterbury Maps and partners and licensed for reuse under the CC BY 4.0 licence
 
+# Shared by LRIS 122982 (areas) and 122985 (points) — identical schema
+__ecan_consented_derived_columns: &ecan_consented_derived_columns
+  - column: current
+    datatype: boolean
+    set_query: |-
+      (
+        CASE
+          WHEN (
+            ConsentStatus = 'Issued - Active'
+            AND Expires::DATE > CURRENT_DATE
+          )
+          OR (
+            Expires::DATE <= CURRENT_DATE
+            AND ConsentStatus = 'Issued - s124 Continuance'
+          )
+          THEN TRUE
+          ELSE FALSE
+        END
+      )
+  - column: start_date
+    datatype: date
+    set_query: "fmDate::DATE"
+  - column: end_date
+    datatype: date
+    set_query: "toDate::DATE"
+  - column: expires_date
+    datatype: date
+    set_query: "Expires::DATE"
+  - column: source_date
+    datatype: daterange
+    set_query: |-
+      CASE
+        WHEN fmDate IS NULL OR toDate IS NULL
+          OR fmDate::DATE > toDate::DATE
+        THEN NULL::daterange
+        ELSE daterange(fmDate::DATE, toDate::DATE, '[]')
+      END
+  - column: source_data
+    datatype: text
+    set_query: "'ECAN consents'::TEXT"
+  - column: source_scale
+    datatype: int4range
+    set_query: |-
+      CASE FEATURE_ACCURACY
+        WHEN '1 metre to 5 metres'
+          THEN '[1,5]'::int4range
+        WHEN '5 metres to 20 metres'
+          THEN '[5,20]'::int4range
+        WHEN 'Greater than 50 metres'
+          THEN '(50,)'::int4range
+        WHEN 'Unknown'
+          THEN '(50,)'::int4range
+        ELSE '(50,)'::int4range
+      END
+
+# Shared by LRIS 122990 (area) and 122991 (point) — identical schema
+# animal_count is TEXT stored as "0.0" floats; FLOAT::INT double-cast required
+__ecan_effluent_derived_columns: &ecan_effluent_derived_columns
+  - column: animal_count
+    datatype: integer
+    set_query: "NULLIF(ActualAnimalNumbers, '')::FLOAT::INT"
+  - column: manage
+    datatype: TEXT[]
+    set_query: |-
+      ARRAY_REMOVE(ARRAY[
+        CASE
+          WHEN DisposalMethod IN (
+            'Centre Pivot',
+            'Dedicated roto-rainer',
+            'Dedicated Spray-effluent only',
+            'Injection - pivot',
+            'Injection k-line',
+            'Pivot - dedicated sprinklers',
+            'Pivot - gun',
+            'Pivot - TI boom',
+            'Spray Irrigation-effluent + water',
+            'Stationary - dedicated k-line',
+            'Stationary - honey pot',
+            'Tanker',
+            'Travelling Irrigator'
+          ) THEN 'irrigation spray'
+          WHEN DisposalMethod IS NOT NULL THEN 'irrigation'
+        END,
+        CASE
+          WHEN CowsWintered LIKE 'Off farm%' THEN 'wintering off'
+          WHEN CowsWintered = 'On farm' THEN 'wintering on'
+        END,
+        CASE WHEN FeedPad = 'Yes' THEN 'feed pad' END,
+        CASE
+          WHEN MilkSupply = 'Town Supply' THEN 'town supply'
+          WHEN MilkSupply = 'Factory Supply' THEN 'factory supply'
+        END
+      ], NULL)::TEXT[]
+  - column: start_date
+    datatype: date
+    set_query: "fmDate::DATE"
+  - column: end_date
+    datatype: date
+    set_query: "toDate::DATE"
+  - column: source_date
+    datatype: daterange
+    set_query: |-
+      CASE
+        WHEN fmDate IS NULL OR toDate IS NULL
+          OR fmDate::DATE > toDate::DATE
+        THEN NULL::daterange
+        ELSE daterange(fmDate::DATE, toDate::DATE, '[]')
+      END
+  - column: source_data
+    datatype: text
+    set_query: "'ECAN consents'::TEXT"
+  - column: source_scale
+    datatype: int4range
+    set_query: |-
+      (CASE FEATURE_ACCURACY
+        WHEN '1 metre to 5 metres'
+          THEN '[1,5]'::int4range
+        WHEN '5 metres to 20 metres'
+          THEN '[5,20]'::int4range
+        WHEN 'Greater than 50 metres'
+          THEN '(50,)'::int4range
+        WHEN 'Unknown'
+          THEN '(50,)'::int4range
+        ELSE '(50,)'::int4range
+      END)
 
 external_data:
   ecan_consented_activities_areas_active:
     <<: *ecan
-    host: https://gis.ecan.govt.nz/arcgis/rest/services/Public/Resource_Consents_Active/MapServer
-    description: Records showing a summary of a current consented activity as recorded within Environment Canterbury's Resource Management Act database.
-      # Records showing a summary of a current consented activity as recorded within Environment Canterbury's Resource Management Act database. This layer contains features that are represented as area of a size 10,000ha or less, and includes feature types such as gravel excavation areas, burnoff areas, etc. Note: Prior to 2013 all actvivties were recorded as point features. Subsequent to this activities may have been captured as line or area features. This layer should be used in conjuction with the Consented Activities - Points, Consented Activities - Lines and Consented Activities - Global layers to get a full representation of all consented activity features. Depending on the nature and conditions of the consent, more than location area may be associated with a single consent. The feature type property indicates the nature of the recorded activity. The layer includes details on: The type of permit (land use consent, discharge permit, etc.), the section of the RMA underwhich the activity was permitted, the current status of the permit (active, in process, etc.), the name of the applicant, a description of the location where the activity related to the permit is undertaken, and if the permit was successfully issued, the period over which the permiitted activities apply. The layer also contains several sumary fields related to spatially defined regions the location lies with including: which territorial local authority(s); the Land and Water Regional Plan groundwater & surface water allocation zones and nutrient management zone; the Canterbury Water Management Strategy (CWMS) zone; the Ngai Tahu Runanga area of interest for Resource Consenting purposes; and the clean air zone.
-    layer: "29"
+    external_data_type: kart
     geom_type: multipolygon
-    derived_columns:
-      - column: current
-        datatype: boolean
-        set_query: |-
-          (
-            CASE
-              WHEN (
-                ConsentStatus = 'Issued - Active'
-                AND Expires > CURRENT_DATE
-              ) 
-              OR (
-                Expires <= CURRENT_DATE
-                AND ConsentStatus = 'Issued - s124 Continuance'
-              )
-              THEN TRUE
-              ELSE FALSE
-            END
-          )
-      - column: start_date
-        datatype: date
-        set_query: "fmDate::DATE"
-      - column: end_date
-        datatype: date
-        set_query: "toDate::DATE"
-      - column: source_date
-        datatype: daterange
-        set_query: daterange(fmDate::DATE, toDate::DATE::DATE, '[]')
-      - column: source_data
-        datatype: text
-        set_query: "'ECAN'::TEXT"
-      - column: source_scale
-        datatype: int4range
-        set_query: |-
-          CASE FEATURE_ACCURACY
-            WHEN '1 metre to 5 metres'
-              THEN '[1,5]'::int4range
-            WHEN '5 metres to 20 metres'
-              THEN '[5,20]'::int4range
-            WHEN 'Greater than 50 metres'
-              THEN '(50,)'::int4range
-            WHEN 'Unknown'
-              THEN '(50,)'::int4range
-            ELSE '(50,)'::int4range
-          END
+    description: ECAN Consented Activities - Areas (Active) (LRIS 122982)
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/ecan-consented-activities-areas-active
+    layer: ecan-consented-activities-areas-active
+    derived_columns: *ecan_consented_derived_columns
     indices:
       - columns: [FeatureType]
         type: btree
@@ -70,88 +159,66 @@ external_data:
         type: btree
         name: idx_current
       - columns:
-        - fmDate DESC NULLS LAST
-        - Expires DESC NULLS LAST
-        - Area_HA DESC NULLS LAST 
+        - start_date DESC NULLS LAST
+        - expires_date DESC NULLS LAST
+        - Area_HA DESC NULLS LAST
         type: btree
         name: idx_btree_sort_order
+
+  ecan_consented_activities_points_active:
+    <<: *ecan
+    external_data_type: kart
+    description: ECAN Consented Activities - Points (Active) (LRIS 122985)
+    geom_type: point
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/ecan-consented-activities-points-active
+    layer: ecan-consented-activities-points-active
+    derived_columns: *ecan_consented_derived_columns
+    indices:
+      - columns: [FeatureType]
+        type: btree
+        name: idx_btree_featuretype
+      - columns: [ConsentType]
+        type: btree
+        name: idx_btree_consenttype
+      - columns: [ActivityText]
+        type: gin
+        name: idx_gin_activitytext
+      - columns: [current]
+        type: btree
+        name: idx_current
+      - columns:
+        - start_date DESC NULLS LAST
+        - expires_date DESC NULLS LAST
+        type: btree
+        name: idx_btree_sort_order
+
   ecan_effluent_dairy_discharge_area:
     <<: *ecan
-    host: https://gis.ecan.govt.nz/arcgis/rest/services/Public/Resource_Consents_Active/MapServer
-    description: Consented Activities - Effluent Dairy Discharge Area (Active)
-      # Consented Activities - Effluent Dairy Discharge Area (Active)
-      # Records showing a summary of a current consented activity related to the storage and discharge of dairy effluent to water or land as recorded within Environment Canterbury's Resource Management Act Database. This layer contains discharge features that are represented as areas less than 10,000ha in size. Note: Prior to 2013 all actvivties were recorded as point features. Subsequent to this activities may have been captured as line or area features. This layer should be used in conjuction with the Consented Activities - Effluent Dairy Discharge Points and Consented Activities - Effluent Dairy Discharge Global layers to get a full representation of all consented activity features. Depending on the nature and conditions of the consent, more than location point may be associated with a single consent. The feature type property indicates the nature of the recorded activity. The layer includes details on: The type of permit (land use consent, discharge permit, etc.), the section of the RMA underwhich the activity was permitted, the current status of the permit (active, in process, etc.), the name of the applicant, a description of the location where the activity related to the permit is undertaken, and if the permit was successfully issued, the period over which the permiitted activities apply. Activity specific details related to dairying practices are also included if relavent. The layer also contains several sumary fields related to spatially defined regions the location lies with including: which territorial local authority(s); the Land and Water Regional Plan groundwater & surface water allocation zones and nutrient management zone; the Canterbury Water Management Strategy (CWMS) zone; the Ngai Tahu Runanga area of interest for Resource Consenting purposes; and the clean air zone.
+    external_data_type: kart
+    description: Consented Activities - Effluent Dairy Discharge Area (Active) (LRIS 122990)
     geom_type: multipolygon
-    layer: "37"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/ecan-consented-activities-effluent-dairy-discharge-area
+    layer: ecan-consented-activities-effluent-dairy-discharge-area
+    derived_columns: *ecan_effluent_derived_columns
+
+  ecan_effluent_dairy_discharge:
+    <<: *ecan
+    external_data_type: kart
+    description: Consented Activities - Effluent Dairy Discharge (Active) (LRIS 122991)
+    geom_type: point
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/ecan-consented-activities-effluent-dairy-discharge
+    layer: ecan-consented-activities-effluent-dairy-discharge
     indices:
       - columns: [animal_count]
         type: btree
-        name: idx_btree_ActualAnimalNumbers_int
-    derived_columns:
-      # ::FLOAT::INT as column is TEXT and "0.0"::INT is invalid input syntax, must be "0.0"::FLOAT::INT (values are counts, but 0 is often recorded as 0.0)
-      - column: animal_count
-        datatype: integer
-        set_query: ActualAnimalNumbers::FLOAT::INT
-      - column: wintering_off
-        datatype: boolean
-        set_query: |-
-          (CASE
-            WHEN CowsWintered LIKE 'Off farm%'
-            THEN true
-            WHEN CowsWintered = 'On farm'
-            THEN false
-            ELSE NULL
-          END)
-      - column: manage
-        datatype: TEXT
-        set_query: |-
-          (CASE
-            WHEN DisposalMethod IN (
-              'Centre Pivot',
-              'Dedicated roto-rainer',
-              'Dedicated Spray-effluent only',
-              'Injection - pivot',
-              'Injection k-line',
-              'Pivot - dedicated sprinklers',
-              'Pivot - gun',
-              'Pivot - TI boom',
-              'Spray Irrigation-effluent + water',
-              'Stationary - dedicated k-line',
-              'Stationary - honey pot',
-              'Tanker',
-              'Travelling Irrigator'
-            )
-            THEN 'irrigation spray'
-            WHEN DisposalMethod IS NOT NULL
-            THEN 'irrigation'
-            ELSE NULL
-          END)
-      - column: start_date
-        datatype: date
-        set_query: "fmDate::DATE"
-      - column: end_date
-        datatype: date
-        set_query: "toDate::DATE"
-      - column: source_date
-        datatype: daterange
-        set_query: daterange(fmDate::DATE, toDate::DATE::DATE, '[]')
-      - column: source_data
-        datatype: text
-        set_query: "'ECAN'::TEXT"
-      - column: source_scale
-        datatype: int4range
-        set_query: |-
-          (CASE FEATURE_ACCURACY
-            WHEN '1 metre to 5 metres'
-              THEN '[1,5]'::int4range
-            WHEN '5 metres to 20 metres'
-              THEN '[5,20]'::int4range
-            WHEN 'Greater than 50 metres'
-              THEN '(50,)'::int4range
-            WHEN 'Unknown'
-              THEN '(50,)'::int4range
-            ELSE '(50,)'::int4range
-          END)
+        name: idx_btree_animal_count
+    derived_columns: *ecan_effluent_derived_columns
 
   ecan_braided_rivers:
     <<: *ecan

--- a/external-data/regional-govt/es.yml
+++ b/external-data/regional-govt/es.yml
@@ -1,3 +1,8 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
 __environment_southland_consents__: &es_public_consents
   external_data_type: arcgis_rest
   license: https://creativecommons.org/licenses/by/4.0/
@@ -70,7 +75,6 @@ external_data:
       - columns: [geom_area_ha]
         type: btree
         name: idx_geom_area_ha
-
 
   es_winter_forage_2017:
     <<: *es_public_general

--- a/external-data/regional-govt/gwrc.yml
+++ b/external-data/regional-govt/gwrc.yml
@@ -64,3 +64,62 @@ external_data:
     layer: "15"
     description: Eastern Area Managed Plantation Forests
     name: GWRC Plantation Forests (Eastern Area)
+
+  gwrc_resource_consents:
+    license: https://creativecommons.org/licenses/by/4.0/
+    attribution: Greater Wellington Regional Council
+    external_data_type: kart
+    geom_type: point
+    description: GWRC Resource Consents (LRIS 123385)
+      # Active status is 'Granted' (not 'Current' — unique to GWRC).
+      # Dairy shed effluent (~400 records): Purpose_Desc ~* '\bdairy shed effluent\b'
+      # AND RC_APT_DESC = 'DP - ANIMAL WASTE TO LAND'.
+    kart:
+      host: kart@data.koordinates.com
+      branch: main
+      commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+      remote: mwlcr/resource-consents
+    layer: resource-consents
+    indices:
+      - columns: [RCstatus]
+        type: btree
+        name: idx_btree_rcstatus
+      - columns: [RC_APT_DESC]
+        type: btree
+        name: idx_btree_rc_apt_desc
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: |-
+          CASE
+            WHEN commencement_date IS NULL OR commencement_date = ''
+            THEN NULL::daterange
+            WHEN GREATEST(
+                TO_DATE(NULLIF("ElapsedDate", ''), 'DD/MM/YYYY'),
+                TO_DATE(NULLIF("ExpiredDate", ''), 'DD/MM/YYYY')
+            ) IS NULL
+            THEN daterange(
+                TO_DATE(commencement_date, 'DD/MM/YYYY'),
+                TO_DATE(commencement_date, 'DD/MM/YYYY'),
+                '[]'
+            )
+            WHEN TO_DATE(commencement_date, 'DD/MM/YYYY') > GREATEST(
+                TO_DATE(NULLIF("ElapsedDate", ''), 'DD/MM/YYYY'),
+                TO_DATE(NULLIF("ExpiredDate", ''), 'DD/MM/YYYY')
+            )
+            THEN NULL::daterange
+            ELSE daterange(
+                TO_DATE(commencement_date, 'DD/MM/YYYY'),
+                GREATEST(
+                    TO_DATE(NULLIF("ElapsedDate", ''), 'DD/MM/YYYY'),
+                    TO_DATE(NULLIF("ExpiredDate", ''), 'DD/MM/YYYY')
+                ),
+                '[]'
+            )
+          END
+      - column: source_data
+        datatype: text
+        set_query: "'GWRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/external-data/regional-govt/hbrc.yml
+++ b/external-data/regional-govt/hbrc.yml
@@ -1,3 +1,8 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
 __hbrc__: &hbrc
   external_data_type: arcgis_rest
   license: null
@@ -21,12 +26,15 @@ external_data:
         name: idx_btree_category
 
   hbrc_all_consent_polygons:
-    <<: *hbrc
     license: https://creativecommons.org/licenses/by/4.0/
-    host: https://gis.hbrc.govt.nz/server/rest/services/ExternalServices/Regulatory/MapServer
-    description: HBRC consents
-    layer: "4"
+    attribution: Hawke's Bay Regional Council
+    external_data_type: kart
     geom_type: multipolygon
+    description: HBRC Regulatory All Consent Polygons (LRIS 123415)
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-regulatory-all-consent-polygons
+    layer: hbrc-regulatory-all-consent-polygons
     indices:
       - columns: [ActPrimaryIndustry]
         type: btree
@@ -34,66 +42,65 @@ external_data:
       - columns: [ActPrimaryIndustry, ActPrimaryPurpose]
         type: btree
         name: idx_btree_ActPrimaryIndustry_ActPrimaryPurpose
+      - columns: [AuthPrimaryIndustry]
+        type: btree
+        name: idx_btree_AuthPrimaryIndustry
+      - columns: [AuthSecondaryIndustry]
+        type: btree
+        name: idx_btree_AuthSecondaryIndustry
       - columns: [ActPrimaryPurpose]
         type: trigram
         name: idx_trgm_ActPrimaryPurpose
       - columns: [ActPrimaryPurpose]
         type: gin
         name: idx_gin_ActPrimaryPurpose
-      - columns: [AuthorisationActivityType]
+      - columns: [Authorisation_Activity_Type]
         type: btree
-        name: idx_gin_AuthorisationActivityType
+        name: idx_btree_Authorisation_Activity_Type
       - columns:
-        - DecisionServedDate DESC NULLS LAST
-        - ExpiryDate DESC NULLS LAST
-        - Area_m2 DESC NULLS LAST 
-        - DocumentLink DESC NULLS LAST
+        - Authorisation_Decision_Date DESC NULLS LAST
+        - Authorisation_Expiry_Date DESC NULLS LAST
+        - Area_m2 DESC NULLS LAST
+        - Document_Link DESC NULLS LAST
         type: btree
         name: idx_btree_sort_order
     derived_columns:
       - column: start_date
         datatype: date
-        set_query: |-
-          CASE
-            WHEN DecisionServedDate IS NOT NULL
-            THEN DecisionServedDate::DATE
-            ELSE NULL
-          END
+        set_query: "Authorisation_Decision_Date::DATE"
       - column: end_date
         datatype: date
-        set_query: |-
-          CASE
-            WHEN ExpiryDate IS NOT NULL
-            THEN ExpiryDate::DATE
-            ELSE NULL
-          END
+        set_query: "Authorisation_Expiry_Date::DATE"
       - column: source_date
         datatype: daterange
         set_query: |-
           CASE
-            WHEN DecisionServedDate IS NULL AND ExpiryDate IS NULL
+            WHEN Authorisation_Decision_Date IS NULL AND Authorisation_Expiry_Date IS NULL
             THEN daterange(CURRENT_DATE, CURRENT_DATE, '(]')
-            WHEN DecisionServedDate IS NOT NULL AND ExpiryDate IS NOT NULL
-            THEN daterange(DecisionServedDate::DATE, ExpiryDate::DATE, '[]')
-            WHEN DecisionServedDate IS NOT NULL
-            THEN daterange(LEAST(CURRENT_DATE, DecisionServedDate::DATE), CURRENT_DATE, '[]')
-            WHEN ExpiryDate IS NOT NULL
-            THEN daterange(CURRENT_DATE, GREATEST(CURRENT_DATE, ExpiryDate::DATE), '[]')
+            WHEN Authorisation_Decision_Date IS NOT NULL AND Authorisation_Expiry_Date IS NOT NULL
+            THEN daterange(Authorisation_Decision_Date::DATE, Authorisation_Expiry_Date::DATE, '[]')
+            WHEN Authorisation_Decision_Date IS NOT NULL
+            THEN daterange(LEAST(CURRENT_DATE, Authorisation_Decision_Date::DATE), CURRENT_DATE, '[]')
+            WHEN Authorisation_Expiry_Date IS NOT NULL
+            THEN daterange(CURRENT_DATE, GREATEST(CURRENT_DATE, Authorisation_Expiry_Date::DATE), '[]')
           END
       - column: source_data
         datatype: text
-        set_query: "'HBRC'::TEXT"
+        set_query: "'HBRC consents'::TEXT"
       - column: source_scale
         datatype: int4range
         set_query: "'[60,200)'::int4range"
 
-  __hbrc_contaminated_sites: &__hbrc_contaminated_sites
-    <<: *hbrc
-    description: HBRC Contaminated Land Use Sites (SLUS)
-    geom_type: multipolygon
+  hbrc_hail_suitable_remediated: &__hbrc_hail_kart
     license: https://creativecommons.org/licenses/by/4.0/
-    layer: '' # NB this is a template
-    host: https://gis.hbrc.govt.nz/server/rest/services/HazardPortal/Contaminated_Sites/MapServer
+    attribution: Hawke's Bay Regional Council
+    external_data_type: kart
+    description: "HBRC HAIL: Suitable for land use: remediated (LRIS 123645)"
+    layer: hbrc-hail-suitable-for-land-use-remediated
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-suitable-for-land-use-remediated
+    geom_type: multipolygon
     derived_columns:
       - column: hail_category_count
         datatype: int
@@ -137,37 +144,58 @@ external_data:
         type: btree
         name: idx_geom_area_ha
 
-  hbrc_hail_suitable_remediated:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: Suitable for land use: remediated"
-    layer: "21"
-
   hbrc_hail_suitable_natural_state:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: Suitable for land use: natural state"
-    layer: "20"
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: Suitable for land use: natural state (LRIS 123644)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-suitable-for-land-use-natural-state
+    layer: hbrc-hail-suitable-for-land-use-natural-state
 
   hbrc_hail_risk_not_quantified:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: risk not quantified"
-    layer: "19"
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: risk not quantified (LRIS 123643)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-risk-not-quantified
+    layer: hbrc-hail-risk-not-quantified
 
   hbrc_hail_managed_for_land_use:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: managed for land use"
-    layer: "18"
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: managed for land use (LRIS 123642)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-managed-for-land-use
+    layer: hbrc-hail-managed-for-land-use
 
   hbrc_hail_contaminated_for_lu_human:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: contaminated for land use: human health"
-    layer: "14"
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: contaminated for land use: human health (LRIS 123641)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-contaminated-for-land-use-human-health
+    layer: hbrc-hail-contaminated-for-land-use-human-health
 
   hbrc_hail_contaminated_for_lu_env:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: contaminated for land use: environment"
-    layer: "12"
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: contaminated for land use: environment (LRIS 123562)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-contaminated-for-land-use-environment
+    layer: hbrc-hail-contaminated-for-land-use-environment
 
   hbrc_hail_background_natural_state:
-    <<: *__hbrc_contaminated_sites
-    description: "HBRC HAIL: at or below background: natural state"
-    layer: "17"
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: at or below background: natural state (LRIS 123543)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/hbrc-hail-at-or-below-background-natural-state
+    layer: hbrc-hail-at-or-below-background-natural-state
+
+  hbrc_hail_background_remediated:
+    <<: *__hbrc_hail_kart
+    description: "HBRC HAIL: at or below background: remediated (LRIS 123548)"
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/contaminated-sites-verified-hail-at-or-below-background-natural-state
+    layer: contaminated-sites-verified-hail-at-or-below-background-natural-state

--- a/external-data/regional-govt/horizons.yml
+++ b/external-data/regional-govt/horizons.yml
@@ -1,73 +1,123 @@
-__horizons__: &horizons
-  external_data_type: arcgis_rest
-  license: null
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+_horizons: &horizons
+  license: https://creativecommons.org/licenses/by/4.0/
   attribution: Horizons Regional Council
 
 external_data:
   horizons_reg_act:
     <<: *horizons
-    license: https://creativecommons.org/licenses/by/4.0/
-    description: Horizons RC regulatory activities (polygon only)
-    host: https://services1.arcgis.com/VuN78wcRdq1Oj69W/arcgis/rest/services/OpenData_RegulatoryActivity/FeatureServer
-    layer: "1"
+    external_data_type: kart
     geom_type: multipolygon
+    description: Horizons Regulatory Activity — Polygon (LRIS 123041)
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/horizons-regulatory-activity-polygon-only
+    layer: horizons-regulatory-activity-polygon-only
     indices:
-      - columns: [Ath_IndPrim]
+      - columns: [PRIMARY_INDUSTRY]
         type: btree
-        name: idx_btree_AthIndPrim
-      - columns: [ATH_PURPRIM]
+        name: idx_btree_primary_industry
+      - columns: [PRIMARY_PURPOSE]
         type: btree
-        name: idx_btree_ATH_PURPRIM
-      - columns: [ATH_PURSEC]
+        name: idx_btree_primary_purpose
+      - columns: [SECONDARY_PURPOSE]
         type: btree
-        name: idx_btree_ATH_PURSEC
-      - columns: [Ath_IndPrim, Ath_PurPrim]
+        name: idx_btree_secondary_purpose
+      - columns: [PRIMARY_INDUSTRY, PRIMARY_PURPOSE]
         type: btree
-        name: idx_btree_Ath_IndPrim_Ath_PurPrim
-      - columns: [Ath_PurPrim]
+        name: idx_btree_industry_purpose
+      - columns: [PRIMARY_PURPOSE]
         type: trigram
-        name: idx_trgm_Ath_PurPrim
-      - columns: [Ath_PurPrim]
+        name: idx_trgm_primary_purpose
+      - columns: [PRIMARY_PURPOSE]
         type: gin
-        name: idx_gin_Ath_PurPrim
-      - columns: [Ath_PurSec]
+        name: idx_gin_primary_purpose
+      - columns: [SECONDARY_PURPOSE]
         type: trigram
-        name: idx_trgm_Ath_PurSec
-      - columns: [Ath_PurSec]
+        name: idx_trgm_secondary_purpose
+      - columns: [SECONDARY_PURPOSE]
         type: gin
-        name: idx_gin_Ath_PurSec
+        name: idx_gin_secondary_purpose
     derived_columns:
       - column: start_date
         datatype: date
-        set_query: |-
-          CASE
-            WHEN Ath_Commence IS NOT NULL
-            THEN Ath_Commence::DATE
-            ELSE NULL
-          END
+        set_query: "COMMENCEMENT_DATE::DATE"
       - column: end_date
         datatype: date
-        set_query: |-
-          CASE
-            WHEN Ath_Expiry IS NOT NULL
-            THEN Ath_Expiry::DATE
-            ELSE NULL
-          END
+        set_query: "EXPIRY_DATE::DATE"
       - column: source_date
         datatype: daterange
         set_query: |-
           CASE
-            WHEN Ath_Granted IS NULL AND DataLastUpdated IS NULL
-            THEN DATERANGE(DataLastUpdated::date, DataLastUpdated::date, '[]')
-            WHEN Ath_Granted IS NOT NULL AND DataLastUpdated IS NOT NULL
-            THEN daterange(Ath_Granted::DATE, DataLastUpdated::DATE, '[]')
-            WHEN Ath_Granted IS NOT NULL
-            THEN daterange(Ath_Granted::DATE, Ath_Granted::DATE, '[]')
-            ELSE daterange(DataLastUpdated::DATE, DataLastUpdated::DATE, '[]')
+            WHEN COMMENCEMENT_DATE IS NULL OR EXPIRY_DATE IS NULL
+              OR COMMENCEMENT_DATE::DATE > EXPIRY_DATE::DATE
+            THEN NULL::daterange
+            ELSE daterange(COMMENCEMENT_DATE::DATE, EXPIRY_DATE::DATE, '[]')
           END
       - column: source_data
         datatype: text
-        set_query: "'Horizons'::TEXT"
+        set_query: "'Horizons consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[60,200)'::int4range"
+
+  horizons_reg_act_point:
+    <<: *horizons
+    external_data_type: kart
+    geom_type: point
+    description: Horizons Regulatory Activity — Point (LRIS 123042)
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/horizons-regulatory-activity-point-only
+    layer: horizons-regulatory-activity-point-only
+    indices:
+      - columns: [PRIMARY_INDUSTRY]
+        type: btree
+        name: idx_btree_primary_industry
+      - columns: [PRIMARY_PURPOSE]
+        type: btree
+        name: idx_btree_primary_purpose
+      - columns: [SECONDARY_PURPOSE]
+        type: btree
+        name: idx_btree_secondary_purpose
+      - columns: [PRIMARY_INDUSTRY, PRIMARY_PURPOSE]
+        type: btree
+        name: idx_btree_industry_purpose
+      - columns: [PRIMARY_PURPOSE]
+        type: trigram
+        name: idx_trgm_primary_purpose
+      - columns: [PRIMARY_PURPOSE]
+        type: gin
+        name: idx_gin_primary_purpose
+      - columns: [SECONDARY_PURPOSE]
+        type: trigram
+        name: idx_trgm_secondary_purpose
+      - columns: [SECONDARY_PURPOSE]
+        type: gin
+        name: idx_gin_secondary_purpose
+    derived_columns:
+      - column: start_date
+        datatype: date
+        set_query: "COMMENCEMENT_DATE::DATE"
+      - column: end_date
+        datatype: date
+        set_query: "EXPIRY_DATE::DATE"
+      - column: source_date
+        datatype: daterange
+        set_query: |-
+          CASE
+            WHEN COMMENCEMENT_DATE IS NULL OR EXPIRY_DATE IS NULL
+              OR COMMENCEMENT_DATE::DATE > EXPIRY_DATE::DATE
+            THEN NULL::daterange
+            ELSE daterange(COMMENCEMENT_DATE::DATE, EXPIRY_DATE::DATE, '[]')
+          END
+      - column: source_data
+        datatype: text
+        set_query: "'Horizons consents'::TEXT"
       - column: source_scale
         datatype: int4range
         set_query: "'[60,200)'::int4range"

--- a/external-data/regional-govt/mdc.yml
+++ b/external-data/regional-govt/mdc.yml
@@ -1,0 +1,66 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+_mdc: &mdc
+  license: https://creativecommons.org/licenses/by/4.0/
+  attribution: Marlborough District Council
+
+external_data:
+  mdc_discharge_polygon:
+    <<: *mdc
+    external_data_type: kart
+    geom_type: polygon
+    description: Marlborough DC Discharge Consents — Polygon (LRIS 123371)
+      # No date fields present; source_date upper-bounded to commit date 2026-06-01.
+      # Dairy signal: ActivityType IN ('Dairy', 'Piggery & Dairy').
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/discharge-land-polygon
+    layer: discharge-land-polygon
+    indices:
+      - columns: [ActivityType]
+        type: btree
+        name: idx_btree_activity_type
+      - columns: [Status]
+        type: btree
+        name: idx_btree_status
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(NULL::DATE, '2026-06-01'::DATE, '(]')"
+      - column: source_data
+        datatype: text
+        set_query: "'MDC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"
+
+  mdc_discharge_point:
+    <<: *mdc
+    external_data_type: kart
+    geom_type: point
+    description: Marlborough DC Discharge Consents — Point (LRIS 123372)
+      # Only 4 dairy records; parcel join needed. No date fields present.
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/discharge-land-point
+    layer: discharge-land-point
+    indices:
+      - columns: [ActivityType]
+        type: btree
+        name: idx_btree_activity_type
+      - columns: [Status]
+        type: btree
+        name: idx_btree_status
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(NULL::DATE, '2026-06-01'::DATE, '(]')"
+      - column: source_data
+        datatype: text
+        set_query: "'MDC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/external-data/regional-govt/orc.yml
+++ b/external-data/regional-govt/orc.yml
@@ -1,0 +1,36 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+external_data:
+  orc_all_consents:
+    license: https://creativecommons.org/licenses/by/4.0/
+    attribution: Otago Regional Council
+    external_data_type: kart
+    geom_type: point
+    description: ORC All Consents (LRIS 123377)
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/otago-regional-council-all-consents
+    layer: otago-regional-council-all-consents
+    indices:
+      - columns: [Consent_Status]
+        type: btree
+        name: idx_btree_consent_status
+      - columns: [activity_tsvector]
+        type: gin
+        name: idx_gin_activity_tsvector
+    derived_columns:
+      - column: activity_tsvector
+        datatype: tsvector
+        set_query: "to_tsvector('english', COALESCE(\"Activity_Purpose\", ''))"
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(NULL::DATE, \"Expiry_Date\"::DATE, '(]')"
+      - column: source_data
+        datatype: text
+        set_query: "'ORC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/external-data/regional-govt/orc.yml
+++ b/external-data/regional-govt/orc.yml
@@ -27,7 +27,7 @@ external_data:
         set_query: "to_tsvector('english', COALESCE(\"Activity_Purpose\", ''))"
       - column: source_date
         datatype: daterange
-        set_query: "daterange(NULL::DATE, \"Expiry_Date\"::DATE, '(]')"
+        set_query: "daterange(NULL::DATE, TO_DATE(NULLIF(\"Expiry_Date\", ''), 'DD/MM/YYYY'), '(]')"
       - column: source_data
         datatype: text
         set_query: "'ORC consents'::TEXT"

--- a/external-data/regional-govt/trc.yml
+++ b/external-data/regional-govt/trc.yml
@@ -1,0 +1,65 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+_trc: &trc
+  license: https://creativecommons.org/licenses/by/4.0/
+  attribution: Taranaki Regional Council
+
+external_data:
+  trc_land_use_consents:
+    <<: *trc
+    external_data_type: kart
+    geom_type: point
+    description: TRC Resource Consents — Land Use Consents (LRIS 124286)
+      # Layer covers waterway structure consents (culverts, bridges, dams, pipelines).
+      # Agricultural use signal comes from PrimaryIndustryPurpose; afforestation
+      # specifically from Activity_Subtype = 'Forestry – Afforestation'.
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/taranaki-regional-council-resource-consents-current-land-use-consent-points
+    layer: taranaki-regional-council-resource-consents-current-land-use-consent-points
+    indices:
+      - columns: [Activity_Subtype]
+        type: btree
+        name: idx_btree_activity_subtype
+      - columns: [PrimaryIndustryPurpose]
+        type: btree
+        name: idx_btree_primary_industry_purpose
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"CommencementDate\"::DATE, \"ExpiryDate\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'TRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"
+
+  trc_discharge_permits:
+    <<: *trc
+    external_data_type: kart
+    geom_type: point
+    description: TRC Resource Consents — Discharge Permits (LRIS 124289)
+      # Agriculture + animal waste subtypes indicate livestock discharge consents.
+      # No dairy-specific subcategory; generic pastoral discharge signal only.
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/taranaki-regional-council-resource-consents-current-discharge-permits-points
+    layer: taranaki-regional-council-resource-consents-current-discharge-permits-points
+    indices:
+      - columns: [PrimaryIndustryPurpose, Activity_Subtype]
+        type: btree
+        name: idx_btree_industry_subtype
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"CommencementDate\"::DATE, \"ExpiryDate\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'TRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/external-data/regional-govt/wcrc.yml
+++ b/external-data/regional-govt/wcrc.yml
@@ -1,0 +1,69 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+_wcrc: &wcrc
+  license: https://creativecommons.org/licenses/by/4.0/
+  attribution: West Coast Regional Council
+
+external_data:
+  wcrc_consent_shapes:
+    <<: *wcrc
+    external_data_type: kart
+    geom_type: polygon
+    description: WCRC Environment Consents — Shapes/Polygon (LRIS 123383)
+      # PrimaryIndustry uses ANZSIC codes. All 1,515 records have CurrentStatus = 'Current'.
+      # Dairy: PrimaryIndustry = 'A0130 Dairy Cattle Farming' (632 records).
+      # Exclude: 'C2121 Milk and Cream Processing' (dairy factory sites, not farms).
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/west-coast-regional-council-environment-consents-consent-shapes
+    layer: west-coast-regional-council-environment-consents-consent-shapes
+    indices:
+      - columns: [PrimaryIndustry]
+        type: btree
+        name: idx_btree_primary_industry
+      - columns: [CurrentStatus]
+        type: btree
+        name: idx_btree_current_status
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"CommencementDate\"::DATE, \"ExpiryDate\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'WCRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"
+
+  wcrc_consent_points:
+    <<: *wcrc
+    external_data_type: kart
+    geom_type: point
+    description: WCRC Environment Consents — Points (LRIS 123381)
+      # Same ANZSIC scheme as wcrc_consent_shapes. All 9,126 records are current.
+      # Dairy (763): 'A0130 Dairy Cattle Farming'. Forestry (156): 'A0301 Forestry'.
+      # Point layer; parcel join needed to expand to farm boundary H3 cells.
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/west-coast-regional-council-environment-consents-consent-points
+    layer: west-coast-regional-council-environment-consents-consent-points
+    indices:
+      - columns: [PrimaryIndustry]
+        type: btree
+        name: idx_btree_primary_industry
+      - columns: [CurrentStatus]
+        type: btree
+        name: idx_btree_current_status
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"CommencementDate\"::DATE, \"ExpiryDate\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'WCRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/external-data/regional-govt/wrc.yml
+++ b/external-data/regional-govt/wrc.yml
@@ -1,0 +1,63 @@
+_kart_mwlcr: &kart_mwlcr
+  host: kart@data.koordinates.com
+  branch: main
+  commit: '`git rev-list -n 1 --first-parent --before="2026-06-01 00:00" main`'
+
+_wrc: &wrc
+  license: https://creativecommons.org/licenses/by/4.0/
+  attribution: Waikato Regional Council
+
+external_data:
+  wrc_land_use_consents:
+    <<: *wrc
+    external_data_type: kart
+    geom_type: point
+    description: WRC Resource Consents — Land Use Consents (LRIS 123531)
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/waikato-regional-council-consents-and-permits-authorisation-resource-consents-land-use-consents
+    layer: waikato-regional-council-consents-and-permits-authorisation-resource-consents-land-use-consents
+    indices:
+      - columns: [PRIMARY_INDUSTRY_PURPOSE]
+        type: btree
+        name: idx_btree_primary_industry_purpose
+      - columns: [STATUS]
+        type: btree
+        name: idx_btree_status
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"COMMENCEMENT_DATE\"::DATE, \"EXPIRY_DATE\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'WRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"
+
+  wrc_discharge_permits:
+    <<: *wrc
+    external_data_type: kart
+    geom_type: point
+    description: WRC Resource Consents — Discharge Permits (LRIS 123533)
+      # PRIMARY_INDUSTRY_PURPOSE signals wired to:
+      #   dairy_effluent_discharge.sql: 'Agricultural farming - dairy'
+      #   intensive_livestock.sql → class_260: 'Agricultural farming - pigs',
+      #     'Agricultural farming - poultry (broiler)'
+      #   forestry.sql: 'Forestry'
+      # Sample remaining (not wired): 'Power generation - hydro', 'Crematoria/cemeteries',
+      #   'Educational/cultural/religious'
+    kart:
+      <<: *kart_mwlcr
+      remote: mwlcr/waikato-regional-council-consents-and-permits-authorisation-resource-consents-discharge-permits
+    layer: waikato-regional-council-consents-and-permits-authorisation-resource-consents-discharge-permits
+    derived_columns:
+      - column: source_date
+        datatype: daterange
+        set_query: "daterange(\"COMMENCEMENT_DATE\"::DATE, \"EXPIRY_DATE\"::DATE, '[]')"
+      - column: source_data
+        datatype: text
+        set_query: "'WRC consents'::TEXT"
+      - column: source_scale
+        datatype: int4range
+        set_query: "'[1,200]'::int4range"

--- a/profiles/nzlum/config.yaml
+++ b/profiles/nzlum/config.yaml
@@ -15,12 +15,18 @@ configfiles:
   - luis-config-nzlum/external-data/mpi/mpi.yml
   - luis-config-nzlum/external-data/stats_nz/stats_nz.yml
 
+  - luis-config-nzlum/external-data/regional-govt/bop.yml
   - luis-config-nzlum/external-data/regional-govt/ecan.yml
+  - luis-config-nzlum/external-data/regional-govt/es.yml
   - luis-config-nzlum/external-data/regional-govt/gdc.yml
   - luis-config-nzlum/external-data/regional-govt/gwrc.yml
   - luis-config-nzlum/external-data/regional-govt/hbrc.yml
   - luis-config-nzlum/external-data/regional-govt/horizons.yml
-  - luis-config-nzlum/external-data/regional-govt/es.yml
+  - luis-config-nzlum/external-data/regional-govt/mdc.yml
+  - luis-config-nzlum/external-data/regional-govt/orc.yml
+  - luis-config-nzlum/external-data/regional-govt/trc.yml
+  - luis-config-nzlum/external-data/regional-govt/wcrc.yml
+  - luis-config-nzlum/external-data/regional-govt/wrc.yml
 
   - luis-config-nzlum/config.default.yml
   - luis-config-nzlum/classifications/nzlum/config.nzlum.yml

--- a/profiles/nzlum/config.yaml
+++ b/profiles/nzlum/config.yaml
@@ -2,7 +2,7 @@ use-conda: true
 conda-frontend: conda
 printshellcmds: true
 use-envmodules: true
-cores: 28
+cores: 56
 rerun-incomplete: true
 configfiles:
   - luis-config-nzlum/external-data/landcare/landcare.yml


### PR DESCRIPTION
Adding consents from district/regional councils:
- BOP
- ECAN
- Environment Southland
- GWRC
- HBRC
- Horzons
- Marlborough DC
- Otago
- West Coast
- Waikato

Inluding point consent layers that get joined to property layers.

15 new layers, and expanded use of some that were already included. 

In all cases, uses Kart repositories associated with LRIS with weekly changes tracked. Those that were already in use as ArcGIS REST API layers have been moved to Kart.